### PR TITLE
공연장 목록 UI

### DIFF
--- a/fe/user/package-lock.json
+++ b/fe/user/package-lock.json
@@ -12,6 +12,8 @@
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.14.14",
         "@mui/material": "^5.14.14",
+        "@mui/x-date-pickers": "^6.16.3",
+        "dayjs": "^1.11.10",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.17.0",
@@ -1340,6 +1342,71 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
+    "node_modules/@mui/x-date-pickers": {
+      "version": "6.16.3",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-6.16.3.tgz",
+      "integrity": "sha512-CBwXrOJ5blqkAdF0d1dWF1RMeCS6ZYDq+53Yf/r+Izqj33+SCw+wAbdrxuIxE2GL3JY5NszEx8JFnCKZIzFZuA==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "@mui/base": "^5.0.0-beta.20",
+        "@mui/utils": "^5.14.14",
+        "@types/react-transition-group": "^4.4.7",
+        "clsx": "^2.0.0",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.8.6",
+        "@mui/system": "^5.8.0",
+        "date-fns": "^2.25.0",
+        "date-fns-jalali": "^2.13.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2487,6 +2554,11 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/fe/user/package.json
+++ b/fe/user/package.json
@@ -15,6 +15,8 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.14.14",
     "@mui/material": "^5.14.14",
+    "@mui/x-date-pickers": "^6.16.3",
+    "dayjs": "^1.11.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.17.0",

--- a/fe/user/src/App.tsx
+++ b/fe/user/src/App.tsx
@@ -1,12 +1,14 @@
-import { ThemeProvider } from '@emotion/react';
-import { designSystem } from '@styles/designSystem';
+import { LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { RouterProvider } from 'react-router-dom';
 import { router } from 'router';
 
 export const App: React.FC = () => {
   return (
     // <ThemeProvider theme={designSystem}>
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
       <RouterProvider router={router} />
+    </LocalizationProvider>
     // </ThemeProvider>
   );
 };

--- a/fe/user/src/components/DatePicker.tsx
+++ b/fe/user/src/components/DatePicker.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+import DateRangeIcon from '@mui/icons-material/DateRange';
+import IconButton from '@mui/material/IconButton';
+import { DateCalendar } from '@mui/x-date-pickers';
+import { useState } from 'react';
+
+export const DatePicker: React.FC = () => {
+  const [calendarOpen, setCalendarOpen] = useState(false);
+
+  return (
+    <StyledDatePicker>
+      <IconButton size="large" onClick={() => setCalendarOpen((co) => !co)}>
+        <DateRangeIcon fontSize="inherit" />
+      </IconButton>
+
+      {calendarOpen && (
+        <DateCalendar
+          sx={{
+            position: 'absolute',
+            right: 0,
+            transform: 'translateY(8px)',
+            boxShadow: '0 4px 4px rgba(0, 0, 0, 0.25)',
+          }}
+        />
+      )}
+    </StyledDatePicker>
+  );
+};
+
+const StyledDatePicker = styled.div`
+  position: relative;
+`;

--- a/fe/user/src/components/PaginationBox.tsx
+++ b/fe/user/src/components/PaginationBox.tsx
@@ -57,13 +57,15 @@ export const PaginationBox: React.FC<Props> = ({
 };
 
 const StyledNavigation = styled.nav`
-  margin-top: 34px;
+  margin: 36px auto;
+  display: flex;
+  justify-content: center;
 `;
 
 const StyledButtonList = styled.ul`
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 12px;
 
   & * {
     font-size: 22px;

--- a/fe/user/src/components/PillShapeButton.tsx
+++ b/fe/user/src/components/PillShapeButton.tsx
@@ -1,0 +1,36 @@
+import styled from '@emotion/styled';
+import ClearIcon from '@mui/icons-material/Clear';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export const PillShapeButton: React.FC<Props> = ({ children }) => {
+  return (
+    <StyledButton>
+      {children}
+      <ClearIcon sx={{ '&:hover, &:active': { cursor: 'pointer', opacity: '0.7' } }} />
+    </StyledButton>
+  );
+};
+
+const StyledButton = styled.button`
+  padding: 10px 24px;
+  border: 1px solid #e1e1e1;
+  border-radius: 30px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #373737;
+  font-size: 16px;
+  font-weight: 600;
+
+  &:hover {
+    cursor: pointer;
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.3);
+  }
+
+  &:active {
+    opacity: 0.7;
+  }
+`;

--- a/fe/user/src/layouts/BaseLayout/Header/index.tsx
+++ b/fe/user/src/layouts/BaseLayout/Header/index.tsx
@@ -4,13 +4,13 @@ import styled from '@emotion/styled';
 export const Header: React.FC = () => {
   return (
     <StyledHeader>
-      <LeftContainer>
-        <LogoImage src="https://github.com/jsh3418/js-calculator-bonobono/assets/57666791/07da94d4-01b3-4e70-8973-db44780f6d6e" />
-        <Buttons>
-          <button>지도</button>
-          <button>문의</button>
-        </Buttons>
-      </LeftContainer>
+      <StyledLeftContainer>
+        <StyledLogoImage src="https://github.com/jsh3418/js-calculator-bonobono/assets/57666791/07da94d4-01b3-4e70-8973-db44780f6d6e" />
+        <StyledButtons>
+          <button type="button">지도</button>
+          <button type="button">문의</button>
+        </StyledButtons>
+      </StyledLeftContainer>
 
       <SearchBar />
     </StyledHeader>
@@ -28,18 +28,18 @@ const StyledHeader = styled.header`
   background-color: #000;
 `;
 
-const LeftContainer = styled.div`
+const StyledLeftContainer = styled.div`
   display: flex;
   gap: 34px;
 `;
 
-const LogoImage = styled.img`
+const StyledLogoImage = styled.img`
   width: 146px;
   height: 27px;
   object-fit: cover;
 `;
 
-const Buttons = styled.nav`
+const StyledButtons = styled.nav`
   display: flex;
   gap: 34px;
 

--- a/fe/user/src/pages/InquiryPage/index.tsx
+++ b/fe/user/src/pages/InquiryPage/index.tsx
@@ -1,13 +1,13 @@
 import { PaginationBox } from '@components/PaginationBox';
 import styled from '@emotion/styled';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { InquiryEditor } from './Editor';
 import { InquiryPageHeader } from './Header';
 import { InquiryData, InquiryList } from './InquiryList';
 import { InquiryTab, TypeFilter } from './TabList';
 
 export const InquiryPage: React.FC = () => {
-  const [maxPage, setMaxPage] = useState<number>(25);
+  const maxPage = useMemo(() => 25, []);
   const [pageNumber, setPageNumber] = useState(
     Math.floor(Math.random() * maxPage),
   );

--- a/fe/user/src/pages/MapPage/Map/index.tsx
+++ b/fe/user/src/pages/MapPage/Map/index.tsx
@@ -15,5 +15,5 @@ export const Map: React.FC = () => {
 
 const StyledMap = styled.div`
   width: 100%;
-  height: 100vh;
+  height: inherit;
 `;

--- a/fe/user/src/pages/MapPage/Panel/VenueList/Header/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueList/Header/index.tsx
@@ -5,43 +5,43 @@ import styled from '@emotion/styled';
 export const Header: React.FC = () => {
   return (
     <StyledHeader>
-      <MainSection>
-        <TotalCount>
+      <StyledMainSection>
+        <StyledTotalCount>
           <h2>전체</h2>
           <span>4</span>
-        </TotalCount>
+        </StyledTotalCount>
 
-        <SortSelect>
+        <StyledSortSelect>
           <option value="">정렬</option>
           <option value="">거리순</option>
           <option value="">최신순</option>
-        </SortSelect>
-      </MainSection>
-      <SubSection>
+        </StyledSortSelect>
+      </StyledMainSection>
+      <StyledSubSection>
         <PillShapeButton>10월13일</PillShapeButton>
         <PillShapeButton>10월14일</PillShapeButton>
         <PillShapeButton>10월15일 19:30</PillShapeButton>
 
         <DatePicker />
-      </SubSection>
+      </StyledSubSection>
     </StyledHeader>
   );
 };
 
 const StyledHeader = styled.div``;
 
-const MainSection = styled.section`
+const StyledMainSection = styled.section`
   display: flex;
   justify-content: space-between;
 `;
 
-const SubSection = styled.section`
+const StyledSubSection = styled.section`
   margin-top: 20px;
   display: flex;
   gap: 8px;
 `;
 
-const TotalCount = styled.div`
+const StyledTotalCount = styled.div`
   display: flex;
   gap: 13px;
   font-size: 26px;
@@ -56,7 +56,7 @@ const TotalCount = styled.div`
   }
 `;
 
-const SortSelect = styled.select`
+const StyledSortSelect = styled.select`
   padding: 4px 0;
   border: none;
   font-size: 22px;

--- a/fe/user/src/pages/MapPage/Panel/VenueList/Header/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueList/Header/index.tsx
@@ -1,0 +1,81 @@
+import { DatePicker } from '@components/DatePicker';
+import { PillShapeButton } from '@components/PillShapeButton';
+import styled from '@emotion/styled';
+
+export const Header: React.FC = () => {
+  return (
+    <StyledHeader>
+      <MainSection>
+        <TotalCount>
+          <h2>전체</h2>
+          <span>4</span>
+        </TotalCount>
+
+        <SortSelect>
+          <option value="">정렬</option>
+          <option value="">거리순</option>
+          <option value="">최신순</option>
+        </SortSelect>
+      </MainSection>
+      <SubSection>
+        <PillShapeButton>10월13일</PillShapeButton>
+        <PillShapeButton>10월14일</PillShapeButton>
+        <PillShapeButton>10월15일 19:30</PillShapeButton>
+
+        <DatePicker />
+      </SubSection>
+    </StyledHeader>
+  );
+};
+
+const StyledHeader = styled.div``;
+
+const MainSection = styled.section`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const SubSection = styled.section`
+  margin-top: 20px;
+  display: flex;
+  gap: 8px;
+`;
+
+const TotalCount = styled.div`
+  display: flex;
+  gap: 13px;
+  font-size: 26px;
+  font-weight: 800;
+
+  & h2 {
+    color: #212121;
+  }
+
+  & span {
+    color: #ff4d00;
+  }
+`;
+
+const SortSelect = styled.select`
+  padding: 4px 0;
+  border: none;
+  font-size: 22px;
+  font-weight: 600;
+  color: #575757;
+  text-align: center;
+
+  &:hover {
+    cursor: pointer;
+    outline: 1px solid #575757;
+  }
+
+  &:focus,
+  &:active {
+    outline: none;
+  }
+
+  & > option:checked {
+    background-color: #DCDCDC;
+    color: #888888;
+  }
+`;

--- a/fe/user/src/pages/MapPage/Panel/VenueList/VenueItem/Description.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueList/VenueItem/Description.tsx
@@ -6,24 +6,24 @@ export const Description: React.FC = () => {
 
   return (
     <StyledDescription>
-      <Header>
-        <Name>연남5701</Name>
-        <Address>서울시 마포구 교동로23길 64</Address>
-      </Header>
+      <StyledHeader>
+        <StyledName>연남5701</StyledName>
+        <StyledAddress>서울시 마포구 교동로23길 64</StyledAddress>
+      </StyledHeader>
 
-      <MainContent>
-        <Introduction>{introduction}</Introduction>
-        <Schedule>
-          <ShowTime>
+      <StyledMainContent>
+        <StyledIntroduction>{introduction}</StyledIntroduction>
+        <StyledSchedule>
+          <StyledShowTime>
             <span>1부</span>
             <span>19:30~20:30</span>
-          </ShowTime>
-          <ShowTime>
+          </StyledShowTime>
+          <StyledShowTime>
             <span>2부</span>
             <span>21:00~22:00</span>
-          </ShowTime>
-        </Schedule>
-      </MainContent>
+          </StyledShowTime>
+        </StyledSchedule>
+      </StyledMainContent>
     </StyledDescription>
   );
 };
@@ -35,31 +35,31 @@ const StyledDescription = styled.article`
   gap: 75px;
 `;
 
-const Header = styled.header`
+const StyledHeader = styled.header`
   display: flex;
   flex-direction: column;
   gap: 8px;
 `;
 
-const Name = styled.h3`
+const StyledName = styled.h3`
   font-size: 24px;
   font-weight: 800;
   color: #1b1b1b;
 `;
 
-const Address = styled.span`
+const StyledAddress = styled.span`
   font-size: 20px;
   font-weight: 500;
   color: #848484;
 `;
 
-const MainContent = styled.section`
+const StyledMainContent = styled.section`
   display: flex;
   flex-direction: column;
   gap: 11px;
 `;
 
-const Introduction = styled.p`
+const StyledIntroduction = styled.p`
   font-size: 20px;
   font-weight: 500;
   color: #5B5B5B;
@@ -72,7 +72,7 @@ const Introduction = styled.p`
   overflow: hidden;
 `;
 
-const Schedule = styled.div`
+const StyledSchedule = styled.div`
   & * {
     font-size: 18px;
     font-weight: 400;
@@ -80,7 +80,7 @@ const Schedule = styled.div`
   }
 `;
 
-const ShowTime = styled.div`
+const StyledShowTime = styled.div`
   display: flex;
   gap: 8px;
 `;

--- a/fe/user/src/pages/MapPage/Panel/VenueList/VenueItem/Description.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueList/VenueItem/Description.tsx
@@ -1,0 +1,86 @@
+import styled from '@emotion/styled';
+
+export const Description: React.FC = () => {
+  const introduction =
+    '인스타그램 : @yeonnam5701\n -재즈음악과 함께 와인을 즐길수 있는공간입니다,\n -와인콜키지는 따로 안되고 있습니다, \n-미성년자는 출입이 불가합니다 .\n -캐치테이블로 예약후 자리는 오시는순서로 원하시는 자리 앉는 방식입니다.\n -캐치테이블 예약금은 오시면 반환되고 따로 입장료 1만원 입니다.\n -주차공간은 6대까지 건물에 가능합니다. 전화문의따로 주시면 됩니다.\n -늘 좋은음악과 좋은 와인으로 함께합니다.';
+
+  return (
+    <StyledDescription>
+      <Header>
+        <Name>연남5701</Name>
+        <Address>서울시 마포구 교동로23길 64</Address>
+      </Header>
+
+      <MainContent>
+        <Introduction>{introduction}</Introduction>
+        <Schedule>
+          <ShowTime>
+            <span>1부</span>
+            <span>19:30~20:30</span>
+          </ShowTime>
+          <ShowTime>
+            <span>2부</span>
+            <span>21:00~22:00</span>
+          </ShowTime>
+        </Schedule>
+      </MainContent>
+    </StyledDescription>
+  );
+};
+
+const StyledDescription = styled.article`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 75px;
+`;
+
+const Header = styled.header`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const Name = styled.h3`
+  font-size: 24px;
+  font-weight: 800;
+  color: #1b1b1b;
+`;
+
+const Address = styled.span`
+  font-size: 20px;
+  font-weight: 500;
+  color: #848484;
+`;
+
+const MainContent = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+`;
+
+const Introduction = styled.p`
+  font-size: 20px;
+  font-weight: 500;
+  color: #5B5B5B;
+  line-height: 1.3;
+  letter-spacing: -4%;
+  white-space: pre-line;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+`;
+
+const Schedule = styled.div`
+  & * {
+    font-size: 18px;
+    font-weight: 400;
+    color: #c6c6c6;
+  }
+`;
+
+const ShowTime = styled.div`
+  display: flex;
+  gap: 8px;
+`;

--- a/fe/user/src/pages/MapPage/Panel/VenueList/VenueItem/Thumbnail.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueList/VenueItem/Thumbnail.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 export const Thumbnail: React.FC = () => {
   return (
     <StyledWrapper>
-      <ThumbnailImage
+      <StyledThumbnail
         src="https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20221111_235%2F1668155402284iEk7x_JPEG%2FKakaoTalk_20221111_172729297.jpg"
         alt=""
       />
@@ -18,7 +18,7 @@ const StyledWrapper = styled.div`
   height: 256px;
 `;
 
-const ThumbnailImage = styled.img`
+const StyledThumbnail = styled.img`
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/fe/user/src/pages/MapPage/Panel/VenueList/VenueItem/Thumbnail.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueList/VenueItem/Thumbnail.tsx
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+
+export const Thumbnail: React.FC = () => {
+  return (
+    <StyledWrapper>
+      <ThumbnailImage
+        src="https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20221111_235%2F1668155402284iEk7x_JPEG%2FKakaoTalk_20221111_172729297.jpg"
+        alt=""
+      />
+    </StyledWrapper>
+  );
+};
+
+const StyledWrapper = styled.div`
+  position: relative;
+
+  width: 256px;
+  height: 256px;
+`;
+
+const ThumbnailImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 10px;
+`;

--- a/fe/user/src/pages/MapPage/Panel/VenueList/VenueItem/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueList/VenueItem/index.tsx
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+import { Description } from './Description';
+import { Thumbnail } from './Thumbnail';
+
+export const VenueItem: React.FC = () => {
+  return (
+    <StyledVenue>
+      <Description />
+      <Thumbnail />
+    </StyledVenue>
+  );
+};
+
+const StyledVenue = styled.div`
+  padding: 20px;
+  display: flex;
+  gap: 40px;
+  border: 1px solid #dbdbdb;
+  border-radius: 8.78px;
+  transition: box-shadow 0.2s ease-in-out;
+
+  &:hover {
+    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
+  }
+
+  &:active {
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1);
+  }
+`;

--- a/fe/user/src/pages/MapPage/Panel/VenueList/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueList/index.tsx
@@ -1,0 +1,71 @@
+import { PaginationBox } from '@components/PaginationBox';
+import styled from '@emotion/styled';
+import { useMemo, useState } from 'react';
+import { Header } from './Header';
+import { VenueItem } from './VenueItem';
+
+export const VenueList: React.FC = () => {
+  const maxPage = useMemo(() => 25, []);
+  const [pageNumber, setPageNumber] = useState(
+    Math.floor(Math.random() * maxPage),
+  );
+
+  const handlePageChange = (
+    event: React.ChangeEvent<unknown>,
+    value: number,
+  ) => {
+    setPageNumber(value);
+  };
+
+  return (
+    <StyledVenueList>
+      <ContentContainer>
+        <Header />
+        <Venues>
+          <VenueItem />
+          <VenueItem />
+          <VenueItem />
+          <VenueItem />
+          <VenueItem />
+        </Venues>
+      </ContentContainer>
+      <PaginationBox
+        maxPage={maxPage}
+        currentPage={pageNumber}
+        onChange={handlePageChange}
+      />
+    </StyledVenueList>
+  );
+};
+
+const StyledVenueList = styled.div`
+  width: 100%;
+  height: inherit;
+  overflow-y: auto;
+
+  &::-webkit-scrollbar {
+    width: 18px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-clip: padding-box;
+    background-color: #c1c1c1;
+    border-radius: 10px;
+    border: 4px solid transparent;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+`;
+
+const ContentContainer = styled.div`
+  padding: 20px;
+`;
+
+const Venues = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-top: 20px;
+`;

--- a/fe/user/src/pages/MapPage/Panel/VenueList/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueList/index.tsx
@@ -19,21 +19,21 @@ export const VenueList: React.FC = () => {
 
   return (
     <StyledVenueList>
-      <ContentContainer>
+      <StyledScrollContainer>
         <Header />
-        <Venues>
+        <StyledVenues>
           <VenueItem />
           <VenueItem />
           <VenueItem />
           <VenueItem />
           <VenueItem />
-        </Venues>
-      </ContentContainer>
-      <PaginationBox
-        maxPage={maxPage}
-        currentPage={pageNumber}
-        onChange={handlePageChange}
-      />
+        </StyledVenues>
+        <PaginationBox
+          maxPage={maxPage}
+          currentPage={pageNumber}
+          onChange={handlePageChange}
+        />
+      </StyledScrollContainer>
     </StyledVenueList>
   );
 };
@@ -59,11 +59,11 @@ const StyledVenueList = styled.div`
   }
 `;
 
-const ContentContainer = styled.div`
+const StyledScrollContainer = styled.div`
   padding: 20px;
 `;
 
-const Venues = styled.ul`
+const StyledVenues = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 20px;

--- a/fe/user/src/pages/MapPage/Panel/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/index.tsx
@@ -1,30 +1,23 @@
 import styled from '@emotion/styled';
+import { VenueList } from './VenueList';
 
 export const Panel: React.FC = () => {
   return (<StyledPanel>
     
-    <VenueList>
-      <Header />
-      <Venues>
-        <VenueItem/>
-        <VenueItem/>
-        <VenueItem/>
-      </Venues>
-      <Pagenation/>
     <VenueList />
       
-    <VenueDetail>
+    {/* <VenueDetail>
       <ImageGrid />
       <Header />
       <BasicInfo />
       <RestInfo />
       { showInfoDetail && <InfoDetail /> }
       { showInfoDetail && createPortal(<Images/> )}
-    </VenueDetail>
+    </VenueDetail> */}
   </StyledPanel>)
 };
 
 const StyledPanel = styled.div`
   width: 100%;
-  height: calc(100% - 73px);
+  height: inherit;
 `;

--- a/fe/user/src/pages/MapPage/index.tsx
+++ b/fe/user/src/pages/MapPage/index.tsx
@@ -12,6 +12,6 @@ export const MapPage: React.FC = () => {
 };
 
 const StyledMapPage = styled.div`
-  height: calc(100% - 73px);
+  height: calc(100vh - 73px);
   display: flex;
 `;


### PR DESCRIPTION
## What is this PR? 👓

지도 페이지 패널의 공연장 목록 UI 구현입니다.

## Key changes 🔑

- DatePicker 컴포넌트를 위해서 `@mui/x-date-pickers`, `dayjs` 패키지 설치하고 App 컴포넌트 LocalizationProvider 세팅했습니다.
- 스크롤을 위해서 MapPage 높이를 `calc(100vh - 73px)`로 수정하고 Map, Panel의 `height: inherit`으로 계산값을 받아왔습니다.

## To reviewers 👋

![image](https://github.com/jazz-meet/jazz-meet/assets/60080167/0822e084-5d4a-40a9-9c55-e34bf6c7abd3)

날짜, 시간 picker 여는 버튼을 따로 두는 것은 어떨까요? 
- DateTimePicker들은 모양이 너무 복잡해보임
- 따로 둬야 시간만 선택하는 상황을 피하기 편할 것 같습니다(버튼을 비할성화해서 제어)