### PR TITLE
feat: 진행 중인 공연 목록 조회 기능 구현

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/image/entity/Image.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/entity/Image.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -16,6 +17,7 @@ public class Image {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+	@Getter
 	@Column(nullable = false)
 	private String url;
 	@Column(nullable = false)

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/controller/ShowController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/controller/ShowController.java
@@ -1,5 +1,6 @@
 package kr.codesquad.jazzmeet.show.controller;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
@@ -18,7 +19,9 @@ public class ShowController {
 
 	@GetMapping("/api/shows/upcoming")
 	public ResponseEntity<List<UpcomingShowResponse>> getUpcomingShows() {
-		List<UpcomingShowResponse> upcomingShowResponses = showService.getUpcomingShows();
+		LocalDateTime nowTime = LocalDateTime.now();
+		List<UpcomingShowResponse> upcomingShowResponses = showService.getUpcomingShows(nowTime);
+
 		return ResponseEntity.ok(upcomingShowResponses);
 	}
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/controller/ShowController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/controller/ShowController.java
@@ -1,0 +1,25 @@
+package kr.codesquad.jazzmeet.show.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.codesquad.jazzmeet.show.dto.response.UpcomingShowResponse;
+import kr.codesquad.jazzmeet.show.service.ShowService;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+public class ShowController {
+
+	private final ShowService showService;
+
+	@GetMapping("/api/shows/upcoming")
+	public ResponseEntity<List<UpcomingShowResponse>> getUpcomingShows() {
+		List<UpcomingShowResponse> upcomingShowResponses = showService.getUpcomingShows();
+		return ResponseEntity.ok(upcomingShowResponses);
+	}
+
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/dto/response/UpcomingShowResponse.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/dto/response/UpcomingShowResponse.java
@@ -1,0 +1,12 @@
+package kr.codesquad.jazzmeet.show.dto.response;
+
+import java.time.LocalDateTime;
+
+public record UpcomingShowResponse(
+	Long venueId,
+	Long showId,
+	String posterUrl,
+	String showName,
+	LocalDateTime startTime,
+	LocalDateTime endTime) {
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/entity/Show.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/entity/Show.java
@@ -16,8 +16,10 @@ import jakarta.persistence.Table;
 import kr.codesquad.jazzmeet.image.entity.Image;
 import kr.codesquad.jazzmeet.venue.entity.Venue;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "`show`")

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/entity/Show.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/entity/Show.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Table;
 import kr.codesquad.jazzmeet.image.entity.Image;
 import kr.codesquad.jazzmeet.venue.entity.Venue;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -41,4 +42,11 @@ public class Show {
 	@JoinColumn(name = "poster_id")
 	private Image poster;
 	private Long adminId;
+
+	@Builder
+	public Show(String teamName, LocalDateTime startTime, LocalDateTime endTime) {
+		this.teamName = teamName;
+		this.startTime = startTime;
+		this.endTime = endTime;
+	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
@@ -1,0 +1,19 @@
+package kr.codesquad.jazzmeet.show.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+import kr.codesquad.jazzmeet.show.dto.response.UpcomingShowResponse;
+import kr.codesquad.jazzmeet.show.entity.Show;
+
+@Mapper
+public interface ShowMapper {
+	ShowMapper INSTANCE = Mappers.getMapper(ShowMapper.class);
+
+	@Mapping(target = "venueId", source = "venue.id")
+	@Mapping(target = "showId", source = "id")
+	@Mapping(target = "posterUrl", source = "poster.url")
+	@Mapping(target = "showName", source = "teamName")
+	UpcomingShowResponse toUpcomingShowResponse(Show show);
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/ShowRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/ShowRepository.java
@@ -3,13 +3,13 @@ package kr.codesquad.jazzmeet.show.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import kr.codesquad.jazzmeet.show.entity.Show;
 
 @Repository
-public interface ShowRepository extends CrudRepository<Show, Long> {
+public interface ShowRepository extends JpaRepository<Show, Long> {
 
 	List<Show> findTop10BystartTimeGreaterThanOrEndTimeGreaterThanOrderByStartTime(LocalDateTime BeforeTime,
 		LocalDateTime upcomingTime);

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/ShowRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/ShowRepository.java
@@ -1,0 +1,16 @@
+package kr.codesquad.jazzmeet.show.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import kr.codesquad.jazzmeet.show.entity.Show;
+
+@Repository
+public interface ShowRepository extends CrudRepository<Show, Long> {
+
+	List<Show> findTop10BystartTimeGreaterThanOrEndTimeGreaterThanOrderByStartTime(LocalDateTime BeforeTime,
+		LocalDateTime upcomingTime);
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowService.java
@@ -1,0 +1,30 @@
+package kr.codesquad.jazzmeet.show.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import kr.codesquad.jazzmeet.show.dto.response.UpcomingShowResponse;
+import kr.codesquad.jazzmeet.show.entity.Show;
+import kr.codesquad.jazzmeet.show.mapper.ShowMapper;
+import kr.codesquad.jazzmeet.show.repository.ShowRepository;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class ShowService {
+
+	private final ShowRepository showRepository;
+
+	public List<UpcomingShowResponse> getUpcomingShows() {
+		LocalDateTime nowTime = LocalDateTime.now();
+
+		// 10개 제한, 현재 시간 < 공연 시작 시간 , 현재 시간 < 공연 끝나는 시간, 공연 시작 시간 순으로 오름차순 정렬
+		List<Show> shows = showRepository.findTop10BystartTimeGreaterThanOrEndTimeGreaterThanOrderByStartTime(
+			nowTime, nowTime);
+		// TODO: image.url만 필요한데 select시 image의 모든 필드를 가져오는 문제를 어떻게 해결할 수 있을까?
+
+		return shows.stream().map(ShowMapper.INSTANCE::toUpcomingShowResponse).toList();
+	}
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowService.java
@@ -17,13 +17,11 @@ public class ShowService {
 
 	private final ShowRepository showRepository;
 
-	public List<UpcomingShowResponse> getUpcomingShows() {
-		LocalDateTime nowTime = LocalDateTime.now();
-
+	public List<UpcomingShowResponse> getUpcomingShows(LocalDateTime nowTime) {
 		// 10개 제한, 현재 시간 < 공연 시작 시간 , 현재 시간 < 공연 끝나는 시간, 공연 시작 시간 순으로 오름차순 정렬
+		// TODO: N+1 문제 해결 필요
 		List<Show> shows = showRepository.findTop10BystartTimeGreaterThanOrEndTimeGreaterThanOrderByStartTime(
 			nowTime, nowTime);
-		// TODO: image.url만 필요한데 select시 image의 모든 필드를 가져오는 문제를 어떻게 해결할 수 있을까?
 
 		return shows.stream().map(ShowMapper.INSTANCE::toUpcomingShowResponse).toList();
 	}

--- a/be/src/test/java/kr/codesquad/jazzmeet/show/service/ShowServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/show/service/ShowServiceTest.java
@@ -1,0 +1,120 @@
+package kr.codesquad.jazzmeet.show.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import kr.codesquad.jazzmeet.IntegrationTestSupport;
+import kr.codesquad.jazzmeet.show.dto.response.UpcomingShowResponse;
+import kr.codesquad.jazzmeet.show.entity.Show;
+import kr.codesquad.jazzmeet.show.repository.ShowRepository;
+
+class ShowServiceTest extends IntegrationTestSupport {
+
+	@Autowired
+	ShowService showService;
+	@Autowired
+	ShowRepository showRepository;
+
+	@AfterEach
+	void dbClean() {
+		showRepository.deleteAllInBatch();
+	}
+
+	@Test
+	@DisplayName("메인 페이지에 방문하면 진행 중인 공연 목록을 조회한다.")
+	void getUpcomingShows() {
+		// given
+		// 공연 목록 생성
+		LocalDateTime nowTime = LocalDateTime.of(2023, Month.OCTOBER, 29, 17, 0);
+		LocalDateTime show1startTime = LocalDateTime.of(2023, Month.OCTOBER, 28, 18, 0);
+		LocalDateTime show1endTime = LocalDateTime.of(2023, Month.OCTOBER, 28, 19, 0);
+		Show show1 = createShow("팀 이름1", show1startTime, show1endTime);// 지난 공연
+		LocalDateTime show2startTime = LocalDateTime.of(2023, Month.OCTOBER, 29, 18, 0);
+		LocalDateTime show2endTime = LocalDateTime.of(2023, Month.OCTOBER, 29, 19, 0);
+		Show show2 = createShow("팀 이름2", show2startTime, show2endTime);// 진행 중인 공연
+		LocalDateTime show3startTime = LocalDateTime.of(2023, Month.OCTOBER, 30, 20, 0);
+		LocalDateTime show3endTime = LocalDateTime.of(2023, Month.OCTOBER, 30, 21, 0);
+		Show show3 = createShow("팀 이름3", show3startTime, show3endTime);// 진행 예정 공연
+
+		// 공연 3개 저장
+		showRepository.save(show1);
+		showRepository.save(show2);
+		showRepository.save(show3);
+
+		// when
+		// 공연 목록을 조회 했을 때
+		List<UpcomingShowResponse> shows = showService.getUpcomingShows(nowTime);
+
+		// then
+		// 1. show1이 없는지 (지난 공연은 포함하지 않는지) 확인
+		// 2. show2, show3가 존재하는지 확인
+		assertThat(shows).extracting(UpcomingShowResponse::showName)
+			.doesNotContain(show1.getTeamName())
+			.contains(show2.getTeamName())
+			.contains(show3.getTeamName());
+	}
+
+	@Test
+	@DisplayName("메인 페이지에 방문하면 진행 중인 공연 목록을 공연 시작 시간이 빠른 순서대로 조회한다.")
+	void getSortedUpcomingShows() {
+		// given
+		// 공연 목록 생성
+		LocalDateTime nowTime = LocalDateTime.of(2023, Month.OCTOBER, 29, 17, 0);
+		LocalDateTime show1startTime = LocalDateTime.of(2023, Month.OCTOBER, 30, 20, 0);
+		LocalDateTime show1endTime = LocalDateTime.of(2023, Month.OCTOBER, 30, 21, 0);
+		Show show1 = createShow("팀 이름3", show1startTime, show1endTime);// 진행 예정 공연2
+		LocalDateTime show2startTime = LocalDateTime.of(2023, Month.OCTOBER, 29, 20, 0);
+		LocalDateTime show2endTime = LocalDateTime.of(2023, Month.OCTOBER, 29, 21, 0);
+		Show show2 = createShow("팀 이름3", show2startTime, show2endTime);// 진행 예정 공연1
+
+		// 공연 2개 저장
+		showRepository.save(show1);
+		showRepository.save(show2);
+
+		// when
+		List<UpcomingShowResponse> shows = showService.getUpcomingShows(nowTime);
+
+		// then
+		// show2 -> show1 순서대로 정렬되어 출력되는지 확인
+		assertThat(shows.get(0).showName()).isEqualTo(show2.getTeamName());
+		assertThat(shows.get(1).showName()).isEqualTo(show1.getTeamName());
+	}
+
+	@Test
+	@DisplayName("메인 페이지에 방문했을 때 진행 중인 공연이 없다면 빈 목록을 조회한다.")
+	void getEmptyUpcomingShows() {
+		// given
+		// 공연 목록 생성
+		LocalDateTime nowTime = LocalDateTime.of(2023, Month.OCTOBER, 29, 17, 0);
+		LocalDateTime show1startTime = LocalDateTime.of(2023, Month.OCTOBER, 27, 20, 0);
+		LocalDateTime show1endTime = LocalDateTime.of(2023, Month.OCTOBER, 27, 21, 0);
+		Show show1 = createShow("팀 이름3", show1startTime, show1endTime);// 진행 예정 공연2
+		LocalDateTime show2startTime = LocalDateTime.of(2023, Month.OCTOBER, 28, 20, 0);
+		LocalDateTime show2endTime = LocalDateTime.of(2023, Month.OCTOBER, 28, 21, 0);
+		Show show2 = createShow("팀 이름3", show2startTime, show2endTime);// 진행 예정 공연1
+
+		// 공연 2개 저장
+		showRepository.save(show1);
+		showRepository.save(show2);
+
+		// when
+		List<UpcomingShowResponse> shows = showService.getUpcomingShows(nowTime);
+
+		// then
+		// 배열이 비어있는지 확인
+		assertThat(shows).isEmpty();
+	}
+
+	Show createShow(String name, LocalDateTime startTime, LocalDateTime endTime) {
+		return Show.builder().teamName(name).startTime(startTime).endTime(endTime).build();
+	}
+
+}


### PR DESCRIPTION
## What is this PR? 👓
- https://github.com/jazz-meet/jazz-meet/issues/22

## Key changes 🔑
- Show의 Controller, Service, Repository, Mapper 만들었습니다.
- **테스트 케이스**
1. 다가오는 공연과 진행 중인 공연만 조회한다.
2. 공연 시작 순서대로 정렬되는지 확인한다.
3. 지난 공연은 조회하지 않는다.

## To reviewers 👋
- ShowRepository에서 조회하는 메서드에 N+1 문제가 있어서 추후에 수정 할 예정입니다.
