### PR TITLE
공연장 상세보기 UI

### DIFF
--- a/fe/user/src/pages/MapPage/Map/index.tsx
+++ b/fe/user/src/pages/MapPage/Map/index.tsx
@@ -1,7 +1,11 @@
 import styled from '@emotion/styled';
 import { useEffect } from 'react';
 
-export const Map: React.FC = () => {
+type Props = {
+  mapRef: React.RefObject<HTMLDivElement>;
+};
+
+export const Map: React.FC<Props> = ({ mapRef }) => {
   useEffect(() => {
     const mapOptions = {
       center: new naver.maps.LatLng(37.5666103, 126.9783882),
@@ -10,7 +14,7 @@ export const Map: React.FC = () => {
     new naver.maps.Map('map', mapOptions);
   }, []);
 
-  return <StyledMap id="map" />;
+  return <StyledMap id="map" ref={mapRef} />;
 };
 
 const StyledMap = styled.div`

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/Images/ImageDetail.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/Images/ImageDetail.tsx
@@ -1,0 +1,64 @@
+import styled from '@emotion/styled';
+import CloseIcon from '@mui/icons-material/Close';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+
+export const ImageDetail: React.FC = () => {
+  return (
+    <StyledImageDetail>
+      <StyledImageDetailHeader>
+        <CloseIcon sx={{ width: '64px', height: '64px', fill: '#B5BEC6' }} />
+      </StyledImageDetailHeader>
+      <StyledImageDetailContent>
+        <ChevronLeftIcon
+          sx={{ width: '64px', height: '64px', fill: '#B5BEC6' }}
+        />
+
+        <StyledImageWrapper>
+          <img
+            src="https://github.com/jazz-meet/jazz-meet/assets/57666791/352473b5-94e8-4234-8645-ea69d6c9b1c1"
+            alt="poster"
+          />
+        </StyledImageWrapper>
+
+        <ChevronRightIcon
+          sx={{ width: '64px', height: '64px', fill: '#B5BEC6' }}
+        />
+      </StyledImageDetailContent>
+    </StyledImageDetail>
+  );
+};
+
+const StyledImageDetail = styled.div`
+  position: fixed;
+  top: 73px;
+  width: 100vw;
+  height: 100vh;
+  background-color: #00000099;
+`;
+
+const StyledImageDetailHeader = styled.div`
+  position: absolute;
+  top: 20px;
+  left: 20px;
+`;
+
+const StyledImageDetailContent = styled.div`
+  height: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 100px;
+  box-sizing: border-box;
+`;
+
+const StyledImageWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+`;

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/Images/ImageDetail.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/Images/ImageDetail.tsx
@@ -31,6 +31,7 @@ export const ImageDetail: React.FC = () => {
 
 const StyledImageDetail = styled.div`
   position: fixed;
+  z-index: 101;
   top: 73px;
   width: 100vw;
   height: 100vh;

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/Images/PreviewImages.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/Images/PreviewImages.tsx
@@ -113,6 +113,7 @@ const StyledImageWrapper = styled.div<{ imagesLength: number }>`
       color: #fff;
       background: rgba(0, 0, 0, 0.3);
       content: '+${({ imagesLength }) => imagesLength - PREVIEW_IMAGE_COUNT}';
+      cursor: pointer;
       display: flex;
       justify-content: center;
       align-items: center;
@@ -126,4 +127,9 @@ const StyledImage = styled.img`
   width: 100%;
   height: 100%;
   object-fit: cover;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.7;
+  }
 `;

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/Images/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/Images/index.tsx
@@ -1,0 +1,12 @@
+import { createPortal } from 'react-dom';
+import { PreviewImages } from './PreviewImages';
+import { ImageDetail } from './ImageDetail';
+
+export const Images: React.FC = () => {
+  return (
+    <>
+      <PreviewImages />
+      {createPortal(<ImageDetail />, document.body)}
+    </>
+  );
+};

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo.tsx
@@ -24,30 +24,42 @@ export const RestInfo: React.FC = () => {
             <ChevronRightIcon sx={{ fill: '#B5BEC6' }} />
           </StyledShowListHeader>
           <StyledShowListContent>
-            <div></div>
-            <div></div>
-            <div>시작</div>
-            <div>종료</div>
+            <StyledShowListContentHeader>
+              <div>시작</div>
+              <div>종료</div>
+            </StyledShowListContentHeader>
 
-            <StyledShowListIndex>01</StyledShowListIndex>
-            <StyledShowListName>권트리오</StyledShowListName>
-            <div>12:00</div>
-            <div>14:00</div>
+            <StyledShowListItem>
+              <StyledShowListItemIndex>01</StyledShowListItemIndex>
+              <StyledShowListItemName>권트리오</StyledShowListItemName>
+              <StyledShowListItemTime>12:00</StyledShowListItemTime>
+              <StyledShowListItemTime>14:00</StyledShowListItemTime>
+            </StyledShowListItem>
 
-            <StyledShowListIndex>02</StyledShowListIndex>
-            <StyledShowListName>김철수 쿼텟</StyledShowListName>
-            <div>12:00</div>
-            <div>14:00</div>
+            <StyledShowListItem>
+              <StyledShowListItemIndex>02</StyledShowListItemIndex>
+              <StyledShowListItemName>김철수 쿼텟</StyledShowListItemName>
+              <StyledShowListItemTime>12:00</StyledShowListItemTime>
+              <StyledShowListItemTime>14:00</StyledShowListItemTime>
+            </StyledShowListItem>
 
-            <StyledShowListIndex>03</StyledShowListIndex>
-            <StyledShowListName>WE 필하모닉스의 피아노 퀀텟</StyledShowListName>
-            <div>12:00</div>
-            <div>14:00</div>
+            <StyledShowListItem>
+              <StyledShowListItemIndex>03</StyledShowListItemIndex>
+              <StyledShowListItemName>
+                WE 필하모닉스의 피아노 퀀텟
+              </StyledShowListItemName>
+              <StyledShowListItemTime>12:00</StyledShowListItemTime>
+              <StyledShowListItemTime>14:00</StyledShowListItemTime>
+            </StyledShowListItem>
 
-            <StyledShowListIndex>04</StyledShowListIndex>
-            <StyledShowListName>러셀 말론 솔로 기타</StyledShowListName>
-            <div>12:00</div>
-            <div>14:00</div>
+            <StyledShowListItem>
+              <StyledShowListItemIndex>04</StyledShowListItemIndex>
+              <StyledShowListItemName>
+                러셀 말론 솔로 기타
+              </StyledShowListItemName>
+              <StyledShowListItemTime>12:00</StyledShowListItemTime>
+              <StyledShowListItemTime>14:00</StyledShowListItemTime>
+            </StyledShowListItem>
           </StyledShowListContent>
         </StyledShowList>
       </StyledRestInfoContent>
@@ -102,21 +114,45 @@ const StyledShowListHeader = styled.div`
 `;
 
 const StyledShowListContent = styled.div`
-  display: grid;
-  grid-template-columns: 40px 1fr 40px 40px;
-  align-items: center;
-  justify-items: center;
+  display: flex;
+  flex-direction: column;
   gap: 14px;
 `;
 
-const StyledShowListIndex = styled.div`
+const StyledShowListContentHeader = styled.div`
+  display: flex;
+  justify-content: end;
+  gap: 14px;
+
+  > div {
+    width: 40px;
+    text-align: center;
+  }
+`;
+
+const StyledShowListItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 14px;
+`;
+
+const StyledShowListItemIndex = styled.div`
+  width: 40px;
   background-color: #d9d9d9;
   padding: 4px 8px;
   border-radius: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 
-const StyledShowListName = styled.div`
+const StyledShowListItemName = styled.div`
+  width: 100%;
   justify-self: start;
+`;
+
+const StyledShowListItemTime = styled.div`
+  width: 40px;
 `;
 
 const StyledContentContainer = styled.div`

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/ShowDetail/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/ShowDetail/index.tsx
@@ -56,6 +56,7 @@ export const ShowDetail: React.FC = () => {
 
 const StyledShowDetail = styled.div`
   position: relative;
+  z-index: 101;
   width: 100%;
   height: 100%;
   padding: 20px;

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/ShowDetail/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/ShowDetail/index.tsx
@@ -1,0 +1,102 @@
+import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useOutletContext } from 'react-router-dom';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import CloseIcon from '@mui/icons-material/Close';
+
+export const ShowDetail: React.FC = () => {
+  // const { id: showId } = useParams();
+  const mapRef = useOutletContext<React.RefObject<HTMLDivElement>>();
+  const [src, setSrc] = useState('');
+
+  useEffect(() => {
+    setSrc(
+      'https://github.com/jazz-meet/jazz-meet/assets/57666791/7beb1dbf-54cb-407a-9494-9ee45e0bb38d',
+    );
+  }, []);
+
+  return (
+    <>
+      {createPortal(
+        <StyledShowDetail>
+          <StyledShowDetailHeader>
+            <CloseIcon
+              sx={{ width: '64px', height: '64px', fill: '#B5BEC6' }}
+            />
+          </StyledShowDetailHeader>
+          <StyledShowDetailBody>
+            <ChevronLeftIcon
+              sx={{ width: '64px', height: '64px', fill: '#B5BEC6' }}
+            />
+            <StyledShowDetailContent>
+              <StyledShowDetailImage>
+                <img src={src} alt="poster" />
+              </StyledShowDetailImage>
+              <StyledShowDetailText>
+                올댓재즈는 1976년부터 한국의 재즈씬을 이끌어온 한국의
+                대표브랜드로서 재즈 매니아들의 성지와도 같은 공간입니다.
+                올댓재즈는 1976년부터 한국의 재즈씬을 이끌어온 한국의
+                대표브랜드로서 재즈 매니아들의 성지와도 같은 공간입니다.
+                올댓재즈는 1976년부터 한국의 재즈씬을 이끌어온 한국의
+                대표브랜드로서 재즈 매니아들의 성지와도 같은 공간입니다.
+              </StyledShowDetailText>
+            </StyledShowDetailContent>
+            <ChevronRightIcon
+              sx={{ width: '64px', height: '64px', fill: '#B5BEC6' }}
+            />
+          </StyledShowDetailBody>
+        </StyledShowDetail>,
+        mapRef.current ?? document.body,
+      )}
+    </>
+  );
+};
+
+const StyledShowDetail = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+  padding: 20px;
+  box-sizing: border-box;
+  background-color: #00000099;
+`;
+
+const StyledShowDetailHeader = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledShowDetailBody = styled.div`
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const StyledShowDetailContent = styled.div`
+  max-width: 500px;
+  height: 100%;
+  overflow-y: auto;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+`;
+
+const StyledShowDetailImage = styled.div`
+  > img {
+    width: 100%;
+    object-fit: contain;
+  }
+`;
+
+const StyledShowDetailText = styled.div`
+  width: 100%;
+  color: #c6c6c6;
+  font-size: 20px;
+  line-height: 130%;
+  margin-bottom: 100px;
+`;

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/index.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
-import { PreviewImages } from './PreviewImages';
 import { Header } from './Header';
 import { BasicInfo } from './BasicInfo';
 import { RestInfo } from './RestInfo';
 import { useEffect, useState } from 'react';
 import { Outlet, useOutletContext } from 'react-router-dom';
+import { Images } from './Images';
 
 export const VenueDetail: React.FC = () => {
   const mapRef = useOutletContext<React.RefObject<HTMLDivElement>>();
@@ -16,7 +16,7 @@ export const VenueDetail: React.FC = () => {
 
   return (
     <StyledVenueDetail isRender={isRender}>
-      <PreviewImages />
+      <Images />
       <Header />
       <BasicInfo />
       <RestInfo />

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/index.tsx
@@ -4,8 +4,10 @@ import { Header } from './Header';
 import { BasicInfo } from './BasicInfo';
 import { RestInfo } from './RestInfo';
 import { useEffect, useState } from 'react';
+import { Outlet, useOutletContext } from 'react-router-dom';
 
 export const VenueDetail: React.FC = () => {
+  const mapRef = useOutletContext<React.RefObject<HTMLDivElement>>();
   const [isRender, setRender] = useState(false);
 
   useEffect(() => {
@@ -18,8 +20,7 @@ export const VenueDetail: React.FC = () => {
       <Header />
       <BasicInfo />
       <RestInfo />
-
-      {/* {showInfoDetail && <InfoDetail />} */}
+      <Outlet context={mapRef} />
       {/* {showInfoDetail && createPortal(<Images />)} */}
     </StyledVenueDetail>
   );

--- a/fe/user/src/pages/MapPage/Panel/VenueList/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueList/index.tsx
@@ -22,7 +22,7 @@ export const VenueList: React.FC = () => {
     <StyledVenueList>
       <Header />
       <StyledVenues>
-        <Link to="/map/1">
+        <Link to="/map/venues/1">
           <VenueItem />
         </Link>
         <VenueItem />

--- a/fe/user/src/pages/MapPage/Panel/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/index.tsx
@@ -1,15 +1,16 @@
 import styled from '@emotion/styled';
 import { VenueList } from './VenueList';
-import { VenueDetail } from './VenueDetail';
-import { useParams } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 
-export const Panel: React.FC = () => {
-  const { id } = useParams();
+type Props = {
+  mapRef: React.RefObject<HTMLDivElement>;
+};
 
+export const Panel: React.FC<Props> = ({ mapRef }) => {
   return (
     <StyledPanel>
       <VenueList />
-      {id && <VenueDetail />}
+      <Outlet context={mapRef} />
     </StyledPanel>
   );
 };

--- a/fe/user/src/pages/MapPage/index.tsx
+++ b/fe/user/src/pages/MapPage/index.tsx
@@ -1,12 +1,15 @@
 import styled from '@emotion/styled';
 import { Map } from './Map';
 import { Panel } from './Panel';
+import { useRef } from 'react';
 
 export const MapPage: React.FC = () => {
+  const mapRef = useRef<HTMLDivElement>(null);
+
   return (
     <StyledMapPage>
-      <Map />
-      <Panel />
+      <Map mapRef={mapRef} />
+      <Panel mapRef={mapRef} />
     </StyledMapPage>
   );
 };

--- a/fe/user/src/router.tsx
+++ b/fe/user/src/router.tsx
@@ -7,6 +7,8 @@ import {
   createBrowserRouter,
   createRoutesFromElements,
 } from 'react-router-dom';
+import { VenueDetail } from '@pages/MapPage/Panel/VenueDetail';
+import { ShowDetail } from '@pages/MapPage/Panel/VenueDetail/ShowDetail';
 
 export const router = createBrowserRouter(
   createRoutesFromElements(
@@ -14,7 +16,9 @@ export const router = createBrowserRouter(
       <Route element={<BaseLayout />}>
         <Route index element={<MainPage />} />
         <Route path="map" element={<MapPage />}>
-          <Route path=":id" element={<MapPage />} />
+          <Route path="venues/:id" element={<VenueDetail />}>
+            <Route path="shows/:id" element={<ShowDetail />} />
+          </Route>
         </Route>
         <Route path="inquiry" element={<InquiryPage />} />
       </Route>


### PR DESCRIPTION
## What is this PR? 👓
공연장 상세보기 UI
이전에 빠진 공연장 사진 상세보기, 공연 상세보기 구현

## Key changes 🔑
- 라우터 변경
  - 공연장 조회 '/map/venus/:id'
  - 공연 상세조회 '/map/venus/:id/shows/:id'

## To reviewers 👋
공연장 사진 상세보기
<img width="1392" alt="image" src="https://github.com/jazz-meet/jazz-meet/assets/57666791/dd20d494-ec3c-4b16-997b-7dc46948ec74">

공연 상세보기
<img width="1392" alt="image" src="https://github.com/jazz-meet/jazz-meet/assets/57666791/70ef8b3a-b1cb-4f85-9c1b-5820c7914705">


