### PR TITLE
공연장 검색 기능 구현

### DIFF
--- a/fe/user/src/components/SearchBar.tsx
+++ b/fe/user/src/components/SearchBar.tsx
@@ -1,29 +1,55 @@
 import SearchIcon from '@mui/icons-material/Search';
 import { IconButton, InputBase, Paper } from '@mui/material';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export const SearchBar: React.FC = () => {
+  const navigate = useNavigate();
+  const [keyword, setKeyword] = useState('');
+
+  const onKeywordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setKeyword(e.target.value);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      searchVenueByKeyword();
+    }
+  };
+
+  const searchVenueByKeyword = () => {
+    navigate(`/map?word=${keyword}`);
+  };
+
   return (
-    <>
-      <Paper
-        component="form"
-        elevation={0}
-        sx={{
-          p: '2px 4px',
-          display: 'flex',
-          alignItems: 'center',
-          width: 490,
-          backgroundColor: '#FFFFFF',
-          backgroundImage: '#FFFFFF',
-        }}
+    <Paper
+      component="form"
+      elevation={0}
+      sx={{
+        p: '2px 4px',
+        display: 'flex',
+        alignItems: 'center',
+        width: 490,
+        backgroundColor: '#FFFFFF',
+        backgroundImage: '#FFFFFF',
+      }}
+    >
+      <InputBase
+        sx={{ ml: 1, flex: 1 }}
+        placeholder="함께 맞는 주말 햇살, 나란히 듣는 재즈."
+        value={keyword}
+        onChange={onKeywordChange}
+        onKeyDown={onKeyDown}
+      />
+      <IconButton
+        type="button"
+        sx={{ p: '10px' }}
+        aria-label="search"
+        onClick={() => searchVenueByKeyword()}
       >
-        <InputBase
-          sx={{ ml: 1, flex: 1 }}
-          placeholder="함께 맞는 주말 햇살, 나란히 듣는 재즈."
-        />
-        <IconButton type="button" sx={{ p: '10px' }} aria-label="search">
-          <SearchIcon />
-        </IconButton>
-      </Paper>
-    </>
+        <SearchIcon />
+      </IconButton>
+    </Paper>
   );
 };

--- a/fe/user/src/components/SearchBar.tsx
+++ b/fe/user/src/components/SearchBar.tsx
@@ -1,37 +1,24 @@
 import SearchIcon from '@mui/icons-material/Search';
 import { IconButton, InputBase, Paper } from '@mui/material';
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 export const SearchBar: React.FC = () => {
   const navigate = useNavigate();
-  const [keyword, setKeyword] = useState('');
 
-  const onKeywordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setKeyword(e.target.value);
-  };
+  const onKeywordSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
 
-  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      searchVenueByKeyword();
+    const keyword = e.currentTarget.keyword.value.trim();
+
+    if (keyword.length > 0) {
+      navigate(`/map?word=${keyword}`);
     }
-  };
-
-  const searchVenueByKeyword = () => {
-    if (keyword.trim().length === 0) {
-      setKeyword('');
-
-      // TODO: (토스트 팝업)빈 검색어로는 검색할 수 없습니다.
-      return;
-    }
-
-    navigate(`/map?word=${keyword}`);
   };
 
   return (
     <Paper
       component="form"
+      onSubmit={onKeywordSubmit}
       elevation={0}
       sx={{
         p: '2px 4px',
@@ -45,16 +32,9 @@ export const SearchBar: React.FC = () => {
       <InputBase
         sx={{ ml: 1, flex: 1 }}
         placeholder="함께 맞는 주말 햇살, 나란히 듣는 재즈."
-        value={keyword}
-        onChange={onKeywordChange}
-        onKeyDown={onKeyDown}
+        name="keyword"
       />
-      <IconButton
-        type="button"
-        sx={{ p: '10px' }}
-        aria-label="search"
-        onClick={() => searchVenueByKeyword()}
-      >
+      <IconButton type="submit" sx={{ p: '10px' }} aria-label="search">
         <SearchIcon />
       </IconButton>
     </Paper>

--- a/fe/user/src/components/SearchBar.tsx
+++ b/fe/user/src/components/SearchBar.tsx
@@ -19,6 +19,13 @@ export const SearchBar: React.FC = () => {
   };
 
   const searchVenueByKeyword = () => {
+    if (keyword.trim().length === 0) {
+      setKeyword('');
+
+      // TODO: (토스트 팝업)빈 검색어로는 검색할 수 없습니다.
+      return;
+    }
+
     navigate(`/map?word=${keyword}`);
   };
 

--- a/fe/user/src/hooks/useVenueList.ts
+++ b/fe/user/src/hooks/useVenueList.ts
@@ -1,7 +1,7 @@
 import { getVenuesByKeyword } from 'apis/venue';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { SearchParams, SearchedVenues } from 'types/api.types';
+import { SearchedVenues } from 'types/api.types';
 
 export const useVenueList = () => {
   const { search } = useLocation();
@@ -15,8 +15,10 @@ export const useVenueList = () => {
 
   const updateVenueList = useCallback(
     async (page?: number) => {
-      const searchParams = getSearchParams(page, urlSearchParams);
-      const searchedVenues = await getVenuesByKeyword(searchParams);
+      const searchedVenues = await getVenuesByKeyword({
+        page,
+        word: urlSearchParams.get('word'),
+      });
 
       setVenueListData(searchedVenues);
     },
@@ -34,21 +36,4 @@ export const useVenueList = () => {
     maxPage: venueListData.maxPage,
     updateVenueList,
   };
-};
-
-const getSearchParams = (
-  page: number | undefined,
-  urlSearchParams: URLSearchParams,
-) => {
-  const searchParams: SearchParams = {};
-
-  if (page && page > 1) {
-    searchParams.page = page;
-  }
-
-  if (urlSearchParams.get('word')) {
-    searchParams.word = urlSearchParams.get('word') ?? '';
-  }
-
-  return searchParams;
 };

--- a/fe/user/src/types/api.types.ts
+++ b/fe/user/src/types/api.types.ts
@@ -22,8 +22,8 @@ export type UpcomingShow = {
 };
 
 export type SearchParams = {
-  word?: string;
-  page?: number;
+  word?: string | null;
+  page?: number | null;
 };
 
 export type SearchedVenues = {

--- a/fe/user/src/utils/getQueryString.ts
+++ b/fe/user/src/utils/getQueryString.ts
@@ -2,7 +2,7 @@ export const getQueryString = (
   params:
     | string
     | string[][]
-    | Record<string, string | number>
+    | Record<string, string | number | undefined | null>
     | URLSearchParams,
 ) => {
   let searchParams: URLSearchParams;
@@ -15,6 +15,10 @@ export const getQueryString = (
     searchParams = new URLSearchParams();
 
     Object.entries(params).forEach(([key, value]) => {
+      if (value === undefined || value === null) {
+        return;
+      }
+
       const paramValue = typeof value === 'number' ? String(value) : value;
       searchParams.append(key, paramValue);
     });


### PR DESCRIPTION
## What is this PR? 👓
검색어를 입력해서 지도 페이지로 이동하는 기능 구현

## Key changes 🔑
- 검색어 입력 후 Enter or 검색 아이콘 클릭하면 query string과 함께 지도 페이지로 이동
- useVenueList에서 query string의 검색어 획득
- 검색어와 페이지로 공연장 목록 조회하기

## To reviewers 👋
- 지도와 관련된 핀 목록 조회쪽은 건드리지 않았습니다.
- page가 1보다 클 때, 그리고 word가 빈 값이 아닐 때 query string에 key 자체가 없었으면 해서 `getSearchParams`라는 함수를 만들었습니다. 일단은 다른 곳에서 활용될지 모르겠어서 컴포넌트에 뒀습니다. 다른 곳에서 활용도가 있다고 생각되면 일반화해서 유틸 함수로 만드는 것도 고려해봄직 합니다.
