### PR TITLE
공연장 상세조회 기능 구현

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ErrorCode.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ErrorCode.java
@@ -11,7 +11,10 @@ public enum ErrorCode implements StatusCode {
 	VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "유효하지 않은 형식입니다."),
 	// 500 Internal Server Error
 	INTERNAL_SERVER_ERROR_DB(HttpStatus.INTERNAL_SERVER_ERROR, "데이터베이스 에러입니다."),
-	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다.");
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다."),
+
+	// -- [Venue] -- //
+	NOT_FOUND_VENUE(HttpStatus.NOT_FOUND, "해당하는 공연장이 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/entity/Image.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/entity/Image.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,4 +25,11 @@ public class Image {
 	private String status;
 	@Column(nullable = false)
 	private LocalDateTime createdAt;
+
+	@Builder
+	public Image(String url, String status, LocalDateTime createdAt) {
+		this.url = url;
+		this.status = status;
+		this.createdAt = createdAt;
+	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/repository/ImageRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/repository/ImageRepository.java
@@ -1,0 +1,10 @@
+package kr.codesquad.jazzmeet.image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import kr.codesquad.jazzmeet.image.entity.Image;
+
+@Repository
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/controller/VenueController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/controller/VenueController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.constraints.Min;
 import kr.codesquad.jazzmeet.venue.dto.response.NearbyVenueResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueAutocompleteResponse;
+import kr.codesquad.jazzmeet.venue.dto.response.VenueDetailResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenuePinsResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueSearchResponse;
 import kr.codesquad.jazzmeet.venue.service.VenueService;
@@ -67,6 +68,16 @@ public class VenueController {
 		VenueSearchResponse venueResponse = venueService.findVenuesByLocation(lowLatitude, highLatitude,
 			lowLongitude, highLongitude, page);
 		return ResponseEntity.ok(venueResponse);
+	}
+
+	/**
+	 * 공연장 상세 조회 API
+	 */
+	@GetMapping("/api/venues/{venueId}")
+	public ResponseEntity<VenueDetailResponse> findVenue(@PathVariable Long venueId) {
+		VenueDetailResponse venue = venueService.findVenue(venueId);
+
+		return ResponseEntity.ok(venue);
 	}
 
 	@GetMapping("/api/venues/search")

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/response/VenueDetailResponse.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/response/VenueDetailResponse.java
@@ -1,0 +1,24 @@
+package kr.codesquad.jazzmeet.venue.dto.response;
+
+import java.util.List;
+
+import kr.codesquad.jazzmeet.venue.vo.VenueDetailImage;
+import kr.codesquad.jazzmeet.venue.vo.VenueDetailLink;
+import kr.codesquad.jazzmeet.venue.vo.VenueDetailVenueHour;
+import lombok.Builder;
+
+@Builder
+public record VenueDetailResponse(
+	Long id,
+	List<VenueDetailImage> images,
+	String name,
+	String roadNameAddress,
+	String lotNumberAddress,
+	String phoneNumber,
+	List<VenueDetailLink> links,
+	List<VenueDetailVenueHour> venueHours,
+	String description,
+	Double latitude,
+	Double longitude
+) {
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/LinkType.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/LinkType.java
@@ -6,8 +6,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class LinkType {
@@ -17,4 +19,8 @@ public class LinkType {
 	private Long id;
 	@Column(nullable = false, length = 20)
 	private String name;
+
+	public LinkType(String name) {
+		this.name = name;
+	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/Venue.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/Venue.java
@@ -1,5 +1,6 @@
 package kr.codesquad.jazzmeet.venue.entity;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.locationtech.jts.geom.Point;
@@ -40,17 +41,20 @@ public class Venue {
 	@Column(length = 500)
 	private String thumbnailUrl;
 	@OneToMany(mappedBy = "venue", cascade = CascadeType.REMOVE, orphanRemoval = true)
-	private List<VenueImage> images;
+	private List<VenueImage> images = new ArrayList<>();
 	@OneToMany(mappedBy = "venue", cascade = CascadeType.REMOVE, orphanRemoval = true)
-	private List<Link> links;
+	private List<Link> links = new ArrayList<>();
 	@OneToMany(mappedBy = "venue", cascade = CascadeType.REMOVE, orphanRemoval = true)
-	private List<VenueHour> venueHours;
+	private List<VenueHour> venueHours = new ArrayList<>();
 
 	@Builder
-	public Venue(String name, String roadNameAddress, String lotNumberAddress, Point location, String thumbnailUrl) {
+	public Venue(String name, String roadNameAddress, String lotNumberAddress, String phoneNumber, String description,
+		Point location, String thumbnailUrl) {
 		this.name = name;
 		this.roadNameAddress = roadNameAddress;
 		this.lotNumberAddress = lotNumberAddress;
+		this.phoneNumber = phoneNumber;
+		this.description = description;
 		this.location = location;
 		this.thumbnailUrl = thumbnailUrl;
 	}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/VenueHour.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/VenueHour.java
@@ -1,5 +1,6 @@
 package kr.codesquad.jazzmeet.venue.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -11,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,7 +28,20 @@ public class VenueHour {
 	private DayOfWeek day;
 	@Column(nullable = false, length = 20)
 	private String businessHour;
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
 	@JoinColumn(name = "venue_id")
 	private Venue venue;
+
+	@Builder
+	public VenueHour(DayOfWeek day, String businessHour, Venue venue) {
+		this.day = day;
+		this.businessHour = businessHour;
+		this.venue = venue;
+	}
+
+	// 연관 관계 편의 메서드
+	public void add(Venue venue) {
+		this.venue = venue;
+		venue.getVenueHours().add(this);
+	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/VenueImage.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/VenueImage.java
@@ -1,5 +1,6 @@
 package kr.codesquad.jazzmeet.venue.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,8 +11,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import kr.codesquad.jazzmeet.image.entity.Image;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class VenueImage {
@@ -21,10 +25,24 @@ public class VenueImage {
 	private Long id;
 	@Column(nullable = false)
 	private Long imageOrder;
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
 	@JoinColumn(name = "venue_id")
 	private Venue venue;
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
 	@JoinColumn(name = "image_id")
 	private Image image;
+
+	@Builder
+	public VenueImage(Long imageOrder, Venue venue, Image image) {
+		this.imageOrder = imageOrder;
+		this.venue = venue;
+		this.image = image;
+	}
+
+	// 연관관계 편의 메서드
+	public void add(Venue venue, Image image) {
+		this.venue = venue;
+		this.image = image;
+		venue.getImages().add(this);
+	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/mapper/VenueMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/mapper/VenueMapper.java
@@ -11,10 +11,12 @@ import kr.codesquad.jazzmeet.venue.dto.ShowInfo;
 import kr.codesquad.jazzmeet.venue.dto.VenueSearch;
 import kr.codesquad.jazzmeet.venue.dto.response.NearbyVenueResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueAutocompleteResponse;
+import kr.codesquad.jazzmeet.venue.dto.response.VenueDetailResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenuePinsResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueSearchResponse;
 import kr.codesquad.jazzmeet.venue.entity.Venue;
 import kr.codesquad.jazzmeet.venue.vo.NearbyVenue;
+import kr.codesquad.jazzmeet.venue.vo.VenueDetail;
 import kr.codesquad.jazzmeet.venue.vo.VenuePins;
 import kr.codesquad.jazzmeet.venue.vo.VenueSearchData;
 
@@ -58,4 +60,8 @@ public interface VenueMapper {
 	@Mapping(target = "longitude", source = "venueSearchData.location.x")
 	@Mapping(target = "showInfo", source = "showInfoList")
 	VenueSearch toVenueSearch(Integer dummy, VenueSearchData venueSearchData, List<ShowInfo> showInfoList);
+
+	@Mapping(target = "latitude", source = "location.y")
+	@Mapping(target = "longitude", source = "location.x")
+	VenueDetailResponse toVenueDetailResponse(VenueDetail venueDetail);
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/VenueHourRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/VenueHourRepository.java
@@ -1,0 +1,10 @@
+package kr.codesquad.jazzmeet.venue.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import kr.codesquad.jazzmeet.venue.entity.VenueHour;
+
+@Repository
+public interface VenueHourRepository extends JpaRepository<VenueHour, Long> {
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/VenueImageRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/VenueImageRepository.java
@@ -1,0 +1,10 @@
+package kr.codesquad.jazzmeet.venue.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import kr.codesquad.jazzmeet.venue.entity.VenueImage;
+
+@Repository
+public interface VenueImageRepository extends JpaRepository<VenueImage, Long> {
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/VenueQueryRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/VenueQueryRepository.java
@@ -1,11 +1,16 @@
 package kr.codesquad.jazzmeet.venue.repository;
 
 import static com.querydsl.core.group.GroupBy.*;
+import static kr.codesquad.jazzmeet.image.entity.QImage.*;
 import static kr.codesquad.jazzmeet.show.entity.QShow.*;
+import static kr.codesquad.jazzmeet.venue.entity.QLink.*;
 import static kr.codesquad.jazzmeet.venue.entity.QVenue.*;
+import static kr.codesquad.jazzmeet.venue.entity.QVenueHour.*;
+import static kr.codesquad.jazzmeet.venue.entity.QVenueImage.*;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
@@ -21,7 +26,12 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import kr.codesquad.jazzmeet.venue.dto.ShowInfo;
+import kr.codesquad.jazzmeet.venue.entity.Venue;
 import kr.codesquad.jazzmeet.venue.vo.NearbyVenue;
+import kr.codesquad.jazzmeet.venue.vo.VenueDetail;
+import kr.codesquad.jazzmeet.venue.vo.VenueDetailImage;
+import kr.codesquad.jazzmeet.venue.vo.VenueDetailLink;
+import kr.codesquad.jazzmeet.venue.vo.VenueDetailVenueHour;
 import kr.codesquad.jazzmeet.venue.vo.VenuePins;
 import kr.codesquad.jazzmeet.venue.vo.VenueSearchData;
 import lombok.RequiredArgsConstructor;
@@ -198,5 +208,62 @@ public class VenueQueryRepository {
 					)
 				)
 			);
+	}
+
+	public Optional<VenueDetail> findVenue(Long venueId) {
+
+		List<VenueDetailVenueHour> venueHours = getVenueHours(venueId);
+		List<VenueDetailLink> links = getLinks(venueId);
+		List<VenueDetailImage> images = getImages(venueId);
+
+		Venue result = query.select(venue)
+			.from(venue)
+			.where(venue.id.eq(venueId))
+			.fetchOne();
+
+		if (result == null) {
+			return Optional.empty();
+		}
+
+		return Optional.of(VenueDetail.builder()
+				.id(result.getId())
+				.name(result.getName())
+				.roadNameAddress(result.getRoadNameAddress())
+				.lotNumberAddress(result.getLotNumberAddress())
+				.phoneNumber(result.getPhoneNumber())
+				.description(result.getDescription())
+				.location(result.getLocation())
+				.images(images)
+				.links(links)
+				.venueHours(venueHours)
+				.build());
+	}
+
+	private List<VenueDetailImage> getImages(Long venueId) {
+		return query.select(Projections.constructor(VenueDetailImage.class,
+				image.id,
+				image.url))
+			.from(venueImage)
+			.leftJoin(venueImage.image, image)
+			.where(venueImage.venue.id.eq(venueId))
+			.fetch();
+	}
+
+	private List<VenueDetailLink> getLinks(Long venueId) {
+		return query.select(Projections.constructor(VenueDetailLink.class,
+				link.linkType,
+				link.url))
+			.from(link)
+			.where(link.venue.id.eq(venueId))
+			.fetch();
+	}
+
+	private List<VenueDetailVenueHour> getVenueHours(Long venueId) {
+		return query.select(Projections.constructor(VenueDetailVenueHour.class,
+				venueHour.day,
+				venueHour.businessHour))
+			.from(venueHour)
+			.where(venueHour.venue.id.eq(venueId))
+			.fetch();
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/VenueQueryRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/VenueQueryRepository.java
@@ -226,17 +226,17 @@ public class VenueQueryRepository {
 		}
 
 		return Optional.of(VenueDetail.builder()
-				.id(result.getId())
-				.name(result.getName())
-				.roadNameAddress(result.getRoadNameAddress())
-				.lotNumberAddress(result.getLotNumberAddress())
-				.phoneNumber(result.getPhoneNumber())
-				.description(result.getDescription())
-				.location(result.getLocation())
-				.images(images)
-				.links(links)
-				.venueHours(venueHours)
-				.build());
+			.id(result.getId())
+			.name(result.getName())
+			.roadNameAddress(result.getRoadNameAddress())
+			.lotNumberAddress(result.getLotNumberAddress())
+			.phoneNumber(result.getPhoneNumber())
+			.description(result.getDescription())
+			.location(result.getLocation())
+			.images(images)
+			.links(links)
+			.venueHours(venueHours)
+			.build());
 	}
 
 	private List<VenueDetailImage> getImages(Long venueId) {

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/VenueRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/VenueRepository.java
@@ -9,6 +9,6 @@ import kr.codesquad.jazzmeet.venue.entity.Venue;
 
 @Repository
 public interface VenueRepository extends JpaRepository<Venue, Long> {
-	
+
 	List<Venue> findTop10ByNameContainingOrRoadNameAddressContaining(String nameWord, String roadNameAddressWord);
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueService.java
@@ -10,9 +10,12 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import kr.codesquad.jazzmeet.global.error.CustomException;
+import kr.codesquad.jazzmeet.global.error.statuscode.ErrorCode;
 import kr.codesquad.jazzmeet.venue.dto.VenueSearch;
 import kr.codesquad.jazzmeet.venue.dto.response.NearbyVenueResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueAutocompleteResponse;
+import kr.codesquad.jazzmeet.venue.dto.response.VenueDetailResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenuePinsResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueSearchResponse;
 import kr.codesquad.jazzmeet.venue.entity.Venue;
@@ -21,6 +24,7 @@ import kr.codesquad.jazzmeet.venue.repository.VenueQueryRepository;
 import kr.codesquad.jazzmeet.venue.repository.VenueRepository;
 import kr.codesquad.jazzmeet.venue.util.VenueUtil;
 import kr.codesquad.jazzmeet.venue.vo.NearbyVenue;
+import kr.codesquad.jazzmeet.venue.vo.VenueDetail;
 import kr.codesquad.jazzmeet.venue.vo.VenuePins;
 import kr.codesquad.jazzmeet.venue.vo.VenueSearchData;
 import lombok.RequiredArgsConstructor;
@@ -112,6 +116,15 @@ public class VenueService {
 	private boolean validateCoordinates(Double lowLatitude, Double highLatitude, Double lowLongitude,
 		Double highLongitude) {
 		return lowLatitude == null || highLatitude == null || lowLongitude == null || highLongitude == null;
+
+	}
+
+	public VenueDetailResponse findVenue(Long venueId) {
+		VenueDetail venueDetail = venueQueryRepository.findVenue(venueId)
+			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_VENUE));
+
+		return VenueMapper.INSTANCE.toVenueDetailResponse(venueDetail);
+
 	}
 
 	public VenueSearchResponse searchVenueList(String word, int page) {

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/vo/VenueDetail.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/vo/VenueDetail.java
@@ -1,0 +1,40 @@
+package kr.codesquad.jazzmeet.venue.vo;
+
+import java.util.List;
+
+import org.locationtech.jts.geom.Point;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class VenueDetail {
+	private Long id;
+	private String name;
+	private String roadNameAddress;
+	private String lotNumberAddress;
+	private String phoneNumber;
+	private String description;
+	private Point location;
+	private List<VenueDetailImage> images;
+	private List<VenueDetailLink> links;
+	private List<VenueDetailVenueHour> venueHours;
+
+	@Builder
+	public VenueDetail(Long id, String name, String roadNameAddress, String lotNumberAddress, String phoneNumber,
+		String description, Point location, List<VenueDetailImage> images, List<VenueDetailLink> links,
+		List<VenueDetailVenueHour> venueHours) {
+		this.id = id;
+		this.name = name;
+		this.roadNameAddress = roadNameAddress;
+		this.lotNumberAddress = lotNumberAddress;
+		this.phoneNumber = phoneNumber;
+		this.description = description;
+		this.location = location;
+		this.images = images;
+		this.links = links;
+		this.venueHours = venueHours;
+	}
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/vo/VenueDetailImage.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/vo/VenueDetailImage.java
@@ -1,0 +1,16 @@
+package kr.codesquad.jazzmeet.venue.vo;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class VenueDetailImage {
+	private Long id;
+	private String url;
+
+	public VenueDetailImage(Long id, String url) {
+		this.id = id;
+		this.url = url;
+	}
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/vo/VenueDetailLink.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/vo/VenueDetailLink.java
@@ -1,0 +1,17 @@
+package kr.codesquad.jazzmeet.venue.vo;
+
+import kr.codesquad.jazzmeet.venue.entity.LinkType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class VenueDetailLink {
+	private String type;
+	private String url;
+
+	public VenueDetailLink(LinkType type, String url) {
+		this.type = type.getName();
+		this.url = url;
+	}
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/vo/VenueDetailVenueHour.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/vo/VenueDetailVenueHour.java
@@ -1,0 +1,17 @@
+package kr.codesquad.jazzmeet.venue.vo;
+
+import kr.codesquad.jazzmeet.venue.entity.DayOfWeek;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class VenueDetailVenueHour {
+	private String day;
+	private String businessHours;
+
+	public VenueDetailVenueHour(DayOfWeek day, String businessHours) {
+		this.day = DayOfWeek.getName(day.ordinal());
+		this.businessHours = businessHours;
+	}
+}

--- a/be/src/test/java/kr/codesquad/jazzmeet/fixture/ImageFixture.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/fixture/ImageFixture.java
@@ -1,0 +1,15 @@
+package kr.codesquad.jazzmeet.fixture;
+
+import java.time.LocalDateTime;
+
+import kr.codesquad.jazzmeet.image.entity.Image;
+
+public class ImageFixture {
+	public static Image createImage(String imageUrl) {
+		return Image.builder()
+			.url(imageUrl)
+			.status("registered")
+			.createdAt(LocalDateTime.now())
+			.build();
+	}
+}

--- a/be/src/test/java/kr/codesquad/jazzmeet/fixture/VenueFixture.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/fixture/VenueFixture.java
@@ -2,7 +2,9 @@ package kr.codesquad.jazzmeet.fixture;
 
 import org.locationtech.jts.geom.Point;
 
+import kr.codesquad.jazzmeet.image.entity.Image;
 import kr.codesquad.jazzmeet.venue.entity.Venue;
+import kr.codesquad.jazzmeet.venue.entity.VenueImage;
 import kr.codesquad.jazzmeet.venue.util.VenueUtil;
 
 public class VenueFixture {
@@ -29,4 +31,11 @@ public class VenueFixture {
 			.build();
 	}
 
+	public static VenueImage createVenueImage(Venue venue, Image image, long imageOrder) {
+		return VenueImage.builder()
+			.venue(venue)
+			.image(image)
+			.imageOrder(imageOrder)
+			.build();
+	}
 }

--- a/be/src/test/java/kr/codesquad/jazzmeet/venue/controller/VenueControllerTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/venue/controller/VenueControllerTest.java
@@ -47,14 +47,13 @@ class VenueControllerTest {
 	@DisplayName("요청으로 들어온 위치의 범위 안에 해당하는 공연장의 위치 정보 목록을 조회한다.")
 	@Test
 	public void findVenuePinsByLocation() throws Exception {
-	    //given
-		Double lowLatitude = 37.51387497068088 ;
-		Double highLatitude = 37.61077342780979 ;
-		Double lowLongitude = 126.9293615244093 ;
-		Double highLongitude = 127.10246683663273 ;
+		//given
+		Double lowLatitude = 37.51387497068088;
+		Double highLatitude = 37.61077342780979;
+		Double lowLongitude = 126.9293615244093;
+		Double highLongitude = 127.10246683663273;
 
-
-	    //when //then
+		//when //then
 		mockMvc.perform(
 				get("/api/venues/pins/map")
 					.queryParam("lowLatitude", String.valueOf(lowLatitude))
@@ -68,18 +67,18 @@ class VenueControllerTest {
 
 	@DisplayName("venue id로 공연장의 상세 정보를 조회한다.")
 	@Test
-	public void findVenueById () throws Exception {
-	    //given
+	public void findVenueById() throws Exception {
+		//given
 		Long venueId = 1L;
 		VenueDetailResponse response = VenueDetailResponse.builder()
 			.id(venueId)
 			.build();
 		when(venueService.findVenue(venueId)).thenReturn(response);
 
-	    //when //then
+		//when //then
 		mockMvc.perform(
-			get("/api/venues/{venueId}", venueId)
-				.contentType(MediaType.APPLICATION_JSON))
+				get("/api/venues/{venueId}", venueId)
+					.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.id").value(venueId));

--- a/be/src/test/java/kr/codesquad/jazzmeet/venue/controller/VenueControllerTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/venue/controller/VenueControllerTest.java
@@ -1,7 +1,9 @@
 package kr.codesquad.jazzmeet.venue.controller;
 
 import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.List;
@@ -14,6 +16,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import kr.codesquad.jazzmeet.venue.dto.response.VenueDetailResponse;
 import kr.codesquad.jazzmeet.venue.service.VenueService;
 
 @WebMvcTest(controllers = VenueController.class)
@@ -61,5 +64,24 @@ class VenueControllerTest {
 					.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$", instanceOf(List.class)));
+	}
+
+	@DisplayName("venue id로 공연장의 상세 정보를 조회한다.")
+	@Test
+	public void findVenueById () throws Exception {
+	    //given
+		Long venueId = 1L;
+		VenueDetailResponse response = VenueDetailResponse.builder()
+			.id(venueId)
+			.build();
+		when(venueService.findVenue(venueId)).thenReturn(response);
+
+	    //when //then
+		mockMvc.perform(
+			get("/api/venues/{venueId}", venueId)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id").value(venueId));
 	}
 }

--- a/be/src/test/java/kr/codesquad/jazzmeet/venue/repository/VenueQueryRepositoryTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/venue/repository/VenueQueryRepositoryTest.java
@@ -18,12 +18,16 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 import kr.codesquad.jazzmeet.IntegrationTestSupport;
+import kr.codesquad.jazzmeet.fixture.ImageFixture;
 import kr.codesquad.jazzmeet.fixture.ShowFixture;
 import kr.codesquad.jazzmeet.fixture.VenueFixture;
+import kr.codesquad.jazzmeet.image.entity.Image;
 import kr.codesquad.jazzmeet.show.entity.Show;
 import kr.codesquad.jazzmeet.show.repository.ShowRepository;
 import kr.codesquad.jazzmeet.venue.entity.Venue;
+import kr.codesquad.jazzmeet.venue.entity.VenueImage;
 import kr.codesquad.jazzmeet.venue.util.VenueUtil;
+import kr.codesquad.jazzmeet.venue.vo.VenueDetail;
 import kr.codesquad.jazzmeet.venue.vo.VenuePins;
 import kr.codesquad.jazzmeet.venue.vo.VenueSearchData;
 
@@ -39,9 +43,15 @@ class VenueQueryRepositoryTest extends IntegrationTestSupport {
 	@Autowired
 	ShowRepository showRepository;
 
+	@Autowired
+	VenueImageRepository venueImageRepository;
+
+	@Autowired
+	VenueHourRepository venueHourRepository;
+
 	@DisplayName("이름에 검색어가 포함되어 있는 공연장 정보 리스트를 조회한다.")
 	@Test
-	public void findVenuesByWordInName() throws Exception {
+	void findVenuesByWordInName() throws Exception {
 		//given
 		String word = "부기우기";
 		Point point = VenueUtil.createPoint(111.111, 222.222);
@@ -60,7 +70,7 @@ class VenueQueryRepositoryTest extends IntegrationTestSupport {
 
 	@DisplayName("주소에 검색어가 포함되어 있는 공연장 정보 리스트를 조회한다.")
 	@Test
-	public void findVenuesByWordInAddress() throws Exception {
+	void findVenuesByWordInAddress() throws Exception {
 		//given
 		String word = "서울";
 		Point point = VenueUtil.createPoint(111.111, 222.222);
@@ -81,7 +91,7 @@ class VenueQueryRepositoryTest extends IntegrationTestSupport {
 
 	@DisplayName("주어진 위치 정보 범위 안에 해당하는 공연장 위치 정보 목록을 조회한다.")
 	@Test
-	public void findVenuesInRange() throws Exception {
+	void findVenuesInRange() throws Exception {
 		//given
 		Double lowLatitude = 37.51387497068088;
 		Double highLatitude = 37.61077342780979;
@@ -193,5 +203,38 @@ class VenueQueryRepositoryTest extends IntegrationTestSupport {
 				.extracting("startTime")
 				.containsExactly(curStartTime1, curStartTime2)
 		);
+	}
+	@DisplayName("venue id에 해당하는 공연장 정보를 조회한다.")
+	@Test
+	void findVenueById () throws Exception {
+	    //given
+		Long venueId = 1L;
+		// 공연장 생성
+		Venue venue = VenueFixture.createVenue("부기우기", "서울 용산구 회나무로 21 2층", VenueUtil.createPoint(37.52387497068088, 126.9294615244093));
+
+		// 이미지 생성
+		Image image1 = ImageFixture.createImage("image1.url");
+		Image image2 = ImageFixture.createImage("image2.url");
+
+		// 공연장_이미지 생성
+		VenueImage venueImage1 = VenueFixture.createVenueImage(venue, image1, 1L);
+		VenueImage venueImage2 = VenueFixture.createVenueImage(venue, image2, 2L);
+
+		// 공연장_이미지 저장
+		venueImage1.add(venue, image1);
+		venueImage2.add(venue, image2);
+		venueImageRepository.saveAll(List.of(venueImage1, venueImage2));
+
+	    //when
+		VenueDetail venueDetail = venueQueryRepository.findVenue(venueId).get();
+
+		//then
+		assertThat(venueDetail)
+			.extracting("name")
+			.isEqualTo("부기우기");
+
+		assertThat(venueDetail.getImages()).hasSize(2)
+			.extracting("url")
+			.contains("image1.url", "image2.url");
 	}
 }

--- a/be/src/test/java/kr/codesquad/jazzmeet/venue/repository/VenueQueryRepositoryTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/venue/repository/VenueQueryRepositoryTest.java
@@ -204,13 +204,15 @@ class VenueQueryRepositoryTest extends IntegrationTestSupport {
 				.containsExactly(curStartTime1, curStartTime2)
 		);
 	}
+
 	@DisplayName("venue id에 해당하는 공연장 정보를 조회한다.")
 	@Test
-	void findVenueById () throws Exception {
-	    //given
+	void findVenueById() throws Exception {
+		//given
 		Long venueId = 1L;
 		// 공연장 생성
-		Venue venue = VenueFixture.createVenue("부기우기", "서울 용산구 회나무로 21 2층", VenueUtil.createPoint(37.52387497068088, 126.9294615244093));
+		Venue venue = VenueFixture.createVenue("부기우기", "서울 용산구 회나무로 21 2층",
+			VenueUtil.createPoint(37.52387497068088, 126.9294615244093));
 
 		// 이미지 생성
 		Image image1 = ImageFixture.createImage("image1.url");
@@ -225,7 +227,7 @@ class VenueQueryRepositoryTest extends IntegrationTestSupport {
 		venueImage2.add(venue, image2);
 		venueImageRepository.saveAll(List.of(venueImage1, venueImage2));
 
-	    //when
+		//when
 		VenueDetail venueDetail = venueQueryRepository.findVenue(venueId).get();
 
 		//then

--- a/be/src/test/java/kr/codesquad/jazzmeet/venue/service/VenueServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/venue/service/VenueServiceTest.java
@@ -12,13 +12,20 @@ import org.locationtech.jts.geom.Point;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import kr.codesquad.jazzmeet.IntegrationTestSupport;
+import kr.codesquad.jazzmeet.fixture.ImageFixture;
 import kr.codesquad.jazzmeet.fixture.VenueFixture;
+import kr.codesquad.jazzmeet.global.error.CustomException;
+import kr.codesquad.jazzmeet.image.entity.Image;
 import kr.codesquad.jazzmeet.venue.dto.VenueSearch;
 import kr.codesquad.jazzmeet.venue.dto.response.NearbyVenueResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueAutocompleteResponse;
+import kr.codesquad.jazzmeet.venue.dto.response.VenueDetailResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenuePinsResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueSearchResponse;
 import kr.codesquad.jazzmeet.venue.entity.Venue;
+import kr.codesquad.jazzmeet.venue.entity.VenueImage;
+import kr.codesquad.jazzmeet.venue.repository.VenueImageRepository;
+import kr.codesquad.jazzmeet.venue.repository.VenueQueryRepository;
 import kr.codesquad.jazzmeet.venue.repository.VenueRepository;
 import kr.codesquad.jazzmeet.venue.util.VenueUtil;
 
@@ -32,6 +39,12 @@ class VenueServiceTest extends IntegrationTestSupport {
 
 	@Autowired
 	private VenueRepository venueRepository;
+
+	@Autowired
+	private VenueQueryRepository venueQueryRepository;
+
+	@Autowired
+	private VenueImageRepository venueImageRepository;
 
 	@AfterEach
 	void dbClean() {
@@ -423,6 +436,56 @@ class VenueServiceTest extends IntegrationTestSupport {
 			.doesNotContain(venue3.getName())
 			.contains(venue1.getName())
 			.contains(venue2.getName());
+	}
+
+	@DisplayName("venue id가 주어지면 해당하는 공연장의 상세 정보를 조회한다.")
+	@Test
+	void findVenue() throws Exception {
+	    //given
+	    Long venueId = 1L;
+		Venue venue = VenueFixture.createVenue("부기우기", "서울 용산구 회나무로 21 2층", VenueUtil.createPoint(37.52387497068088, 126.9294615244093));
+
+		Image image1 = ImageFixture.createImage("image1.url");
+		Image image2 = ImageFixture.createImage("image2.url");
+
+		VenueImage venueImage1 = VenueFixture.createVenueImage(venue, image1, 1L);
+		VenueImage venueImage2 = VenueFixture.createVenueImage(venue, image2, 2L);
+
+		venueImage1.add(venue, image1);
+		venueImage2.add(venue, image2);
+
+		venueImageRepository.saveAll(List.of(venueImage1, venueImage2));
+
+		//when
+		VenueDetailResponse venueResponse = venueService.findVenue(venueId);
+
+		//then
+		assertThat(venueResponse)
+			.extracting("name")
+			.isEqualTo("부기우기");
+	}
+
+	@DisplayName("venue id에 해당하는 공연장이 없으면 예외를 응답한다.")
+	@Test
+	void findVenueWhenNotExistVenue() throws Exception {
+	    //given
+	    Long venueId = 2L;
+		Venue venue = VenueFixture.createVenue("부기우기", "서울 용산구 회나무로 21 2층", VenueUtil.createPoint(37.52387497068088, 126.9294615244093));
+
+		Image image1 = ImageFixture.createImage("image1.url");
+		Image image2 = ImageFixture.createImage("image2.url");
+
+		VenueImage venueImage1 = VenueFixture.createVenueImage(venue, image1, 1L);
+		VenueImage venueImage2 = VenueFixture.createVenueImage(venue, image2, 2L);
+
+		venueImage1.add(venue, image1);
+		venueImage2.add(venue, image2);
+
+		venueImageRepository.saveAll(List.of(venueImage1, venueImage2));
+
+		//when //then
+		assertThatThrownBy(() -> venueService.findVenue(venueId))
+			.isInstanceOf(CustomException.class);
 	}
 
 }

--- a/be/src/test/java/kr/codesquad/jazzmeet/venue/service/VenueServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/venue/service/VenueServiceTest.java
@@ -441,9 +441,10 @@ class VenueServiceTest extends IntegrationTestSupport {
 	@DisplayName("venue id가 주어지면 해당하는 공연장의 상세 정보를 조회한다.")
 	@Test
 	void findVenue() throws Exception {
-	    //given
-	    Long venueId = 1L;
-		Venue venue = VenueFixture.createVenue("부기우기", "서울 용산구 회나무로 21 2층", VenueUtil.createPoint(37.52387497068088, 126.9294615244093));
+		//given
+		Long venueId = 1L;
+		Venue venue = VenueFixture.createVenue("부기우기", "서울 용산구 회나무로 21 2층",
+			VenueUtil.createPoint(37.52387497068088, 126.9294615244093));
 
 		Image image1 = ImageFixture.createImage("image1.url");
 		Image image2 = ImageFixture.createImage("image2.url");
@@ -468,9 +469,10 @@ class VenueServiceTest extends IntegrationTestSupport {
 	@DisplayName("venue id에 해당하는 공연장이 없으면 예외를 응답한다.")
 	@Test
 	void findVenueWhenNotExistVenue() throws Exception {
-	    //given
-	    Long venueId = 2L;
-		Venue venue = VenueFixture.createVenue("부기우기", "서울 용산구 회나무로 21 2층", VenueUtil.createPoint(37.52387497068088, 126.9294615244093));
+		//given
+		Long venueId = 2L;
+		Venue venue = VenueFixture.createVenue("부기우기", "서울 용산구 회나무로 21 2층",
+			VenueUtil.createPoint(37.52387497068088, 126.9294615244093));
 
 		Image image1 = ImageFixture.createImage("image1.url");
 		Image image2 = ImageFixture.createImage("image2.url");


### PR DESCRIPTION
## What is this PR? 👓
공연장 상세 조회 기능을 구현했습니다.

## Key changes 🔑
연관관계 편의 메서드와 연관 관계를 가지는 엔티티 인스턴스들을 한 번에 persist 하기 위해 엔티티 cascade 조건을 수정하고 list를 필드에서 초기화했습니다.    
테스트에서 사용하기 위해 repository 몇 개를 만들었는데 이후에 crud 만들려면 필요한 거라 상관 없을거라 생각합니다.

## To reviewers 👋
원래 venue에 links, images, hours 모두 만들어서 넣을 생각이었는데 한 번 venueImage에 save하니까 persist가 날아가버려 이후에 hours를 저장할 때 persist가 안됐습니다. 그래서 일단 images에 대한 테스트만 진행했습니다. 이에 대한 것은 학습 후에 추가하도록 하겠습니다.    
또한, VenueDetail을 불러올 때 list가 여러 개 가져와야 하는데 transfrom()을 사용하면 중복이 발생하여 처리가 힘들었습니다. 일단 서브쿼리로 구현했는데 더 좋은 방법이 있다면 알려주세요!
