### PR TITLE
Be/fix/#111 공연장 목록 조회에서 공연 전체 개수 네이밍 수정

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/response/VenueSearchResponse.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/response/VenueSearchResponse.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 @Builder
 public record VenueSearchResponse(
 	List<VenueSearch> venues,
-	long venueCount,
+	long totalCount,
 	int currentPage,
 	long maxPage) {
 	public static VenueSearchResponse emptyVenues() {

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/mapper/VenueMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/mapper/VenueMapper.java
@@ -17,6 +17,9 @@ import kr.codesquad.jazzmeet.venue.dto.response.VenueSearchResponse;
 import kr.codesquad.jazzmeet.venue.entity.Venue;
 import kr.codesquad.jazzmeet.venue.vo.NearbyVenue;
 import kr.codesquad.jazzmeet.venue.vo.VenueDetail;
+import kr.codesquad.jazzmeet.venue.vo.VenueDetailImage;
+import kr.codesquad.jazzmeet.venue.vo.VenueDetailLink;
+import kr.codesquad.jazzmeet.venue.vo.VenueDetailVenueHour;
 import kr.codesquad.jazzmeet.venue.vo.VenuePins;
 import kr.codesquad.jazzmeet.venue.vo.VenueSearchData;
 
@@ -64,4 +67,16 @@ public interface VenueMapper {
 	@Mapping(target = "latitude", source = "location.y")
 	@Mapping(target = "longitude", source = "location.x")
 	VenueDetailResponse toVenueDetailResponse(VenueDetail venueDetail);
+
+	default VenueDetail toVenueDetail(Venue venue,
+		List<VenueDetailImage> images, List<VenueDetailLink> links, List<VenueDetailVenueHour> venueHours) {
+		Integer dummy = null;
+		return toVenueDatail(dummy, venue, images, links, venueHours);
+	}
+
+	@Mapping(target = "images", source = "images")
+	@Mapping(target = "links", source = "links")
+	@Mapping(target = "venueHours", source = "venueHours")
+	VenueDetail toVenueDatail(Integer dummy, Venue venue,
+		List<VenueDetailImage> images, List<VenueDetailLink> links, List<VenueDetailVenueHour> venueHours);
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/mapper/VenueMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/mapper/VenueMapper.java
@@ -38,14 +38,14 @@ public interface VenueMapper {
 	VenuePinsResponse toVenuePinsBySearchResponse(VenuePins venuePinsByWord);
 
 	default VenueSearchResponse toVenueSearchResponse(List<VenueSearch> venueSearchList,
-		long venueCount, int currentPage, long maxPage) {
+		long totalCount, int currentPage, long maxPage) {
 		Integer dummy = null;
-		return toVenueSearchResponse(dummy, venueSearchList, venueCount, currentPage, maxPage);
+		return toVenueSearchResponse(dummy, venueSearchList, totalCount, currentPage, maxPage);
 	}
 
 	@Mapping(target = "venues", source = "venueSearchList")
 	VenueSearchResponse toVenueSearchResponse(Integer dummy, List<VenueSearch> venueSearchList,
-		long venueCount, int currentPage, long maxPage);
+		long totalCount, int currentPage, long maxPage);
 
 	default VenueSearch toVenueSearch(VenueSearchData venueSearchData) {
 		Integer dummy = null;

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/VenueQueryRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/VenueQueryRepository.java
@@ -182,7 +182,7 @@ public class VenueQueryRepository {
 	private JPAQuery<Long> countSearchVenueList(String word) {
 		return query.select(venue.count())
 			.from(venue)
-			.where(venue.name.contains(word).or(venue.roadNameAddress.contains(word)));
+			.where(isContainWordInName(word).or(isContainWordInAddress(word)));
 	}
 
 	public List<VenueSearchData> findVenueSearchById(Long venueId, LocalDate curDate) {

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/VenueQueryRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/VenueQueryRepository.java
@@ -27,6 +27,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import kr.codesquad.jazzmeet.venue.dto.ShowInfo;
 import kr.codesquad.jazzmeet.venue.entity.Venue;
+import kr.codesquad.jazzmeet.venue.mapper.VenueMapper;
 import kr.codesquad.jazzmeet.venue.vo.NearbyVenue;
 import kr.codesquad.jazzmeet.venue.vo.VenueDetail;
 import kr.codesquad.jazzmeet.venue.vo.VenueDetailImage;
@@ -224,19 +225,8 @@ public class VenueQueryRepository {
 		if (result == null) {
 			return Optional.empty();
 		}
-
-		return Optional.of(VenueDetail.builder()
-			.id(result.getId())
-			.name(result.getName())
-			.roadNameAddress(result.getRoadNameAddress())
-			.lotNumberAddress(result.getLotNumberAddress())
-			.phoneNumber(result.getPhoneNumber())
-			.description(result.getDescription())
-			.location(result.getLocation())
-			.images(images)
-			.links(links)
-			.venueHours(venueHours)
-			.build());
+		
+		return Optional.of(VenueMapper.INSTANCE.toVenueDetail(result, images, links, venueHours));
 	}
 
 	private List<VenueDetailImage> getImages(Long venueId) {


### PR DESCRIPTION
## What is this PR? 👓
venueCount -> totalCount 네이밍 수정 완료

## To reviewers 👋
- 네이밍 수정하면서 시오가 venueQueryRepository에서 builder 사용한 부분 Mapper로 변경했습니다.
- venueQueryRepository에서 word로 공연장 이름과 주소를 확인하던 비교 연산을 기존에 있던 BooleanExpression 메서드를 사용하는 것으로 변경했습니다.
