### PR TITLE
공연장 단독 목록, 상세정보

### DIFF
--- a/fe/user/src/apis/venue.ts
+++ b/fe/user/src/apis/venue.ts
@@ -64,7 +64,7 @@ export const getVenuesByKeyword = async (
 
 export const getVenuesByMapBounds = async (
   searchBoundsParams: SearchBoundsParams = {}
-) => {
+): Promise<SearchedVenues> => {
   const queryString = getQueryString(searchBoundsParams);
   const response = await fetchData(`/api/venues/map${queryString}`);
 

--- a/fe/user/src/apis/venue.ts
+++ b/fe/user/src/apis/venue.ts
@@ -3,6 +3,7 @@ import {
   Pin,
   SearchBoundsParams,
   SearchParams,
+  SearchSuggestion,
   SearchedVenues,
   VenueDetailData,
 } from '~/types/api.types';
@@ -71,7 +72,15 @@ export const getVenuesByMapBounds = async (
   return response.json();
 };
 
-export const getSearchSuggestions = async (word: string) => {
+
+export const getSingleVenue = async (venueId: number): Promise<SearchedVenues> => {
+  const response = await fetchData(`/api/venues/search/${venueId}`);
+
+  return response.json();
+}
+
+
+export const getSearchSuggestions = async (word: string): Promise<SearchSuggestion[]> => {
   const response = await fetchData(`/api/search?word=${word}`);
 
   return response.json();

--- a/fe/user/src/components/SearchBox/SuggestionBox/SuggestionItem.tsx
+++ b/fe/user/src/components/SearchBox/SuggestionBox/SuggestionItem.tsx
@@ -12,7 +12,7 @@ export const SuggestionItem: React.FC<Props> = ({ suggestion, onClose }) => {
   const navigate = useNavigate();
 
   const navigateToVenueDetail = () => {
-    navigate(`/map/venues/${suggestion.id}`);
+    navigate(`/map?venueId=${suggestion.id}`);
     onClose();
   };
 

--- a/fe/user/src/hooks/useMarkers.ts
+++ b/fe/user/src/hooks/useMarkers.ts
@@ -36,7 +36,7 @@ export const useMarkers = ({
         searchQueryString.includes('highLongitude')
       ) {
         pins.current = await getVenuePinsByMapBounds(searchQueryString);
-      } else {
+      } else if (!searchQueryString.includes('venueId')) {
         const bounds = map.current.getBounds();
 
         if (!(bounds instanceof naver.maps.LatLngBounds)) {
@@ -82,6 +82,10 @@ export const useMarkers = ({
       markersOnMap.current = addPinsOnMap(venueList, map.current, 'marker');
 
       fitBoundsToCoordinateBoundary(searchQueryString, map.current);
+    } else if (searchQueryString.includes('venueId')) {
+      markersOnMap.current = addPinsOnMap(venueList, map.current, 'marker');
+
+      fitBoundsToPins(venueList, map.current);
     } else {
       pinsOnMap.current = addPinsOnMap(filteredPins, map.current, 'pin');
       markersOnMap.current = addPinsOnMap(venueList, map.current, 'marker');

--- a/fe/user/src/hooks/useVenueList.ts
+++ b/fe/user/src/hooks/useVenueList.ts
@@ -5,7 +5,7 @@ import { SearchedVenues, VenueData } from '~/types/api.types';
 
 export type VenueListData = {
   venueList: VenueData[];
-  venueCount: number;
+  totalCount: number;
   currentPage: number;
   maxPage: number;
   updateVenueList: (page: number) => void;
@@ -16,7 +16,7 @@ export const useVenueList = () => {
   const urlSearchParams = useMemo(() => new URLSearchParams(search), [search]);
   const [venueListData, setVenueListData] = useState<SearchedVenues>({
     venues: [],
-    venueCount: 0,
+    totalCount: 0,
     currentPage: 1,
     maxPage: 1,
   });
@@ -46,7 +46,7 @@ export const useVenueList = () => {
 
   return {
     venueList: venueListData.venues,
-    venueCount: venueListData.venueCount,
+    totalCount: venueListData.totalCount,
     currentPage: venueListData.currentPage,
     maxPage: venueListData.maxPage,
     updateVenueList,

--- a/fe/user/src/hooks/useVenueList.ts
+++ b/fe/user/src/hooks/useVenueList.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { getVenuesByKeyword, getVenuesByMapBounds } from '~/apis/venue';
+import {
+  getSingleVenue,
+  getVenuesByKeyword,
+  getVenuesByMapBounds,
+} from '~/apis/venue';
 import { SearchedVenues, VenueData } from '~/types/api.types';
 
 export type VenueListData = {
@@ -30,9 +34,12 @@ export const useVenueList = () => {
         lowLongitude: Number(urlSearchParams.get('lowLongitude')!),
         highLongitude: Number(urlSearchParams.get('highLongitude')!),
       };
+      const venueId = urlSearchParams.get('venueId');
 
       const searchedVenues = word
         ? await getVenuesByKeyword({ page, word })
+        : venueId
+        ? await getSingleVenue(Number(venueId))
         : await getVenuesByMapBounds({ page, ...coordinateBoundary });
 
       setVenueListData(searchedVenues);

--- a/fe/user/src/pages/MainPage/MainSection/CardList/Cards/AroundVenueCard.tsx
+++ b/fe/user/src/pages/MainPage/MainSection/CardList/Cards/AroundVenueCard.tsx
@@ -7,15 +7,11 @@ type Props = {
 };
 
 export const AroundVenueCard: React.FC<Props> = ({ aroundVenue }) => {
-  const { id, thumbnailUrl, name, address, latitude, longitude } = aroundVenue;
+  const { id, thumbnailUrl, name, address } = aroundVenue;
   const navigate = useNavigate();
 
   return (
-    <StyledCard
-      onClick={() =>
-        navigate(`/map/venues/${id}`, { state: { latitude, longitude } })
-      }
-    >
+    <StyledCard onClick={() => navigate(`/map?venueId=${id}`)}>
       <StyledCardImage src={thumbnailUrl} alt="around-venue" />
       <StyledTitleContainer>
         <StyledTitle>{name}</StyledTitle>

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/index.tsx
@@ -25,7 +25,6 @@ export const VenueDetail: React.FC = () => {
   }));
 
   useEffect(() => {
-    setRender(true);
     return () => setPreviousPath(currentLocation.pathname);
   }, []);
 
@@ -41,6 +40,14 @@ export const VenueDetail: React.FC = () => {
 
     updateDate();
   }, [venueId]);
+
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+
+    setRender(true);
+  }, [data]);
 
   return (
     <>
@@ -67,6 +74,7 @@ export const VenueDetail: React.FC = () => {
 };
 
 const StyledVenueDetail = styled.div<{ isRender: boolean }>`
+  box-sizing: border-box;
   width: 100%;
   height: 100%;
   overflow-y: auto;

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/index.tsx
@@ -1,21 +1,32 @@
 import styled from '@emotion/styled';
-import { Header } from './Header';
-import { BasicInfo } from './BasicInfo';
-import { RestInfo } from './RestInfo';
 import { useEffect, useState } from 'react';
-import { Outlet, useOutletContext, useParams } from 'react-router-dom';
-import { Images } from './Images';
-import { VenueDetailData } from '~/types/api.types';
+import {
+  Outlet,
+  useLocation,
+  useOutletContext,
+  useParams,
+} from 'react-router-dom';
 import { getVenueDetail } from '~/apis/venue';
+import { usePathHistoryStore } from '~/stores/usePathHistoryStore';
+import { VenueDetailData } from '~/types/api.types';
+import { BasicInfo } from './BasicInfo';
+import { Header } from './Header';
+import { Images } from './Images';
+import { RestInfo } from './RestInfo';
 
 export const VenueDetail: React.FC = () => {
   const { venueId } = useParams();
+  const currentLocation = useLocation();
   const mapRef = useOutletContext<React.RefObject<HTMLDivElement>>();
   const [isRender, setRender] = useState(false);
   const [data, setData] = useState<VenueDetailData>();
+  const { setPreviousPath } = usePathHistoryStore((state) => ({
+    setPreviousPath: state.setPreviousPath,
+  }));
 
   useEffect(() => {
     setRender(true);
+    return () => setPreviousPath(currentLocation.pathname);
   }, []);
 
   useEffect(() => {

--- a/fe/user/src/pages/MapPage/Panel/VenueList/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueList/index.tsx
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import { Link } from 'react-router-dom';
-import { VenueItem } from './VenueItem';
 import { PaginationBox } from '~/components/PaginationBox';
 import { VenueListData } from '~/hooks/useVenueList';
+import { VenueItem } from './VenueItem';
 
 export const VenueList: React.FC<VenueListData> = ({
   venueList,
-  venueCount,
+  totalCount,
   currentPage,
   maxPage,
   updateVenueList,
@@ -20,7 +20,7 @@ export const VenueList: React.FC<VenueListData> = ({
     <StyledVenueList>
       <StyledTotalCount>
         <h2>전체</h2>
-        <span>{venueCount}</span>
+        <span>{totalCount}</span>
       </StyledTotalCount>
 
       {venueList.length > 0 ? (

--- a/fe/user/src/pages/MapPage/Panel/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/index.tsx
@@ -1,13 +1,39 @@
 import styled from '@emotion/styled';
-import { VenueList } from './VenueList';
-import { Outlet } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { useShallow } from 'zustand/react/shallow';
 import { VenueListData } from '~/hooks/useVenueList';
+import { usePathHistoryStore } from '~/stores/usePathHistoryStore';
+import { VenueList } from './VenueList';
 
 type Props = {
   mapRef: React.RefObject<HTMLDivElement>;
 } & VenueListData;
 
 export const Panel: React.FC<Props> = ({ mapRef, ...venueListData }) => {
+  const navigate = useNavigate();
+  const { search } = useLocation();
+  const { previousPath, setPreviousPath } = usePathHistoryStore(
+    useShallow((state) => ({
+      previousPath: state.previousPath,
+      setPreviousPath: state.setPreviousPath,
+    })),
+  );
+
+  useEffect(() => {
+    const venueId = new URLSearchParams(search).get('venueId');
+    const detailPath = `/map/venues/${venueId}`;
+
+    // 자동 이동 방지
+    if (venueId && previousPath !== detailPath) {
+      navigate(detailPath);
+    }
+  }, [search, navigate, previousPath]);
+
+  useEffect(() => {
+    return () => setPreviousPath('');
+  }, []);
+
   return (
     <StyledPanel>
       <VenueList {...venueListData} />

--- a/fe/user/src/pages/MapPage/index.tsx
+++ b/fe/user/src/pages/MapPage/index.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 import { useRef } from 'react';
+import { useVenueList } from '~/hooks/useVenueList';
 import { Map } from './Map';
 import { Panel } from './Panel';
-import { useVenueList } from '~/hooks/useVenueList';
 
 export const MapPage: React.FC = () => {
   const venueListData = useVenueList();
@@ -17,6 +17,7 @@ export const MapPage: React.FC = () => {
 };
 
 const StyledMapPage = styled.div`
+  overflow: hidden;
   height: calc(100vh - 73px);
   display: flex;
 `;

--- a/fe/user/src/stores/usePathHistoryStore.ts
+++ b/fe/user/src/stores/usePathHistoryStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+type PathHistoryStore = {
+  previousPath: string;
+  setPreviousPath: (previousPath: string) => void;
+};
+
+export const usePathHistoryStore = create<PathHistoryStore>((set) => ({
+  previousPath: '',
+  setPreviousPath: (previousPath: string) => set(() => ({ previousPath })),
+}));

--- a/fe/user/src/types/api.types.ts
+++ b/fe/user/src/types/api.types.ts
@@ -47,7 +47,7 @@ export type SearchBoundsParams = {
 
 export type SearchedVenues = {
   venues: VenueData[];
-  venueCount: number;
+  totalCount: number;
   currentPage: number;
   maxPage: number;
 };


### PR DESCRIPTION
## What is this PR? 👓
근처 공연장 또는 검색어 제안에서 공연장을 클릭할 경우의 동작.
해당 공연장만 지도와 목록에 있는 페이지로 이동하고, 공연장의 상세정보 layer를 띄운다.

## Key changes 🔑
- getSingleVenue 함수 추가
- 근처 공연장, 검색어 제안 목록 클릭 시 이동 경로 수정
- 쿼리스트링에 venueId 있는 경우 마커, 공연장 목록 렌더링 동작 추가

## To reviewers 👋
- 쿼리스트링에 venueId 있는 경우, 상세정보 레이어를 열기위해 Effect 사용
- 뒤로가기시 자동이동을 막기 위해 usePathHistoryStore에 이전 경로 추가하도록 했습니다.
- 상세정보 레이어 열리는 애니메이션이 동작하지 않아서 임의로 손봤습니다.
- 상세정보로 이동하는 경로에 쿼리스트링을 뺐더니 마커와 공연장 목록이 화면에 보이는 지도 기준으로 검색되는 것 같습니다. 
