### PR TITLE
공연장 등록 기능 구현

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ImageErrorCode.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ImageErrorCode.java
@@ -10,7 +10,8 @@ public enum ImageErrorCode implements StatusCode{
 	// -- [Image] -- //
 	IMAGE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다."),
 	NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "해당하는 이미지가 없습니다."),
-	WRONG_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 파일 형식입니다.");
+	WRONG_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 파일 형식입니다."),
+	IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지는 최대 10개까지 등록할 수 있습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/VenueErrorCode.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/VenueErrorCode.java
@@ -7,8 +7,15 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public enum VenueErrorCode implements StatusCode {
 
+	// -- [Venue] -- //
 	INVALID_LOCATION_ERROR(HttpStatus.BAD_REQUEST, "잘못된 위치 정보입니다."),
-	NOT_FOUND_VENUE(HttpStatus.NOT_FOUND, "해당하는 공연장이 없습니다.");
+	NOT_FOUND_VENUE(HttpStatus.NOT_FOUND, "해당하는 공연장이 없습니다."),
+
+	// -- [LinkType] -- //
+	NOT_FOUND_LINK_TYPE(HttpStatus.NOT_FOUND, "해당하는 링크 타입이 없습니다."),
+
+	// -- [DayOfWeek] -- //
+	NOT_FOUND_DAY_OF_WEEK(HttpStatus.NOT_FOUND, "해당하는 요일이 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/controller/ImageController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/controller/ImageController.java
@@ -23,6 +23,9 @@ public class ImageController {
 	private final CloudService cloudService;
 	private final ImageService imageService;
 
+	/**
+	 * 이미지 업로드 API
+	 */
 	@PostMapping("/api/images")
 	public ResponseEntity<ImageIdsResponse> uploadImages(@RequestPart("image") List<MultipartFile> multipartFiles) {
 		List<String> imageUrls = cloudService.uploadImages(multipartFiles);
@@ -31,6 +34,9 @@ public class ImageController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(imageIdsResponse);
 	}
 
+	/**
+	 * 이미지 삭제 API
+	 */
 	@DeleteMapping("/api/images/{imageId}")
 	public ResponseEntity<Void> deleteImage(@PathVariable Long imageId) {
 		imageService.deleteImage(imageId);

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/dto/response/ImageIdsResponse.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/dto/response/ImageIdsResponse.java
@@ -2,16 +2,7 @@ package kr.codesquad.jazzmeet.image.dto.response;
 
 import java.util.List;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor
-@Getter
-public class ImageIdsResponse {
-
-	private List<Long> ids;
-
-	public ImageIdsResponse(List<Long> ids) {
-		this.ids = ids;
-	}
+public record ImageIdsResponse (
+	List<Long> ids
+) {
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
@@ -46,4 +46,9 @@ public class ImageService {
 
 		image.updateStatus(ImageStatus.DELETED);
 	}
+
+	public Image findById(Long imageId) {
+		return imageRepository.findById(imageId)
+			.orElseThrow(() -> new CustomException(ImageErrorCode.NOT_FOUND_IMAGE));
+	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/controller/VenueController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/controller/VenueController.java
@@ -20,7 +20,7 @@ import kr.codesquad.jazzmeet.venue.dto.response.VenueCreateResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueDetailResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenuePinsResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueSearchResponse;
-import kr.codesquad.jazzmeet.venue.service.VenueCreateFacade;
+import kr.codesquad.jazzmeet.venue.service.VenueFacade;
 import kr.codesquad.jazzmeet.venue.service.VenueService;
 import lombok.RequiredArgsConstructor;
 
@@ -30,7 +30,7 @@ import lombok.RequiredArgsConstructor;
 public class VenueController {
 
 	private final VenueService venueService;
-	private final VenueCreateFacade venueCreateFacade;
+	private final VenueFacade venueFacade;
 
 	/**
 	 * 검색어 자동완성 목록 조회 API
@@ -118,7 +118,8 @@ public class VenueController {
 	 */
 	@PostMapping("/api/venues")
 	public ResponseEntity<VenueCreateResponse> createVenue(@RequestBody VenueCreateRequest venueCreateRequest) {
-		VenueCreateResponse venueCreateResponse = venueCreateFacade.createVenue(venueCreateRequest);
+		VenueCreateResponse venueCreateResponse = venueFacade.createVenue(venueCreateRequest);
+
 		return ResponseEntity.status(HttpStatus.CREATED).body(venueCreateResponse);
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/controller/VenueController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/controller/VenueController.java
@@ -2,19 +2,25 @@ package kr.codesquad.jazzmeet.venue.controller;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.constraints.Min;
+import kr.codesquad.jazzmeet.venue.dto.request.VenueCreateRequest;
 import kr.codesquad.jazzmeet.venue.dto.response.NearbyVenueResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueAutocompleteResponse;
+import kr.codesquad.jazzmeet.venue.dto.response.VenueCreateResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueDetailResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenuePinsResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueSearchResponse;
+import kr.codesquad.jazzmeet.venue.service.VenueCreateFacade;
 import kr.codesquad.jazzmeet.venue.service.VenueService;
 import lombok.RequiredArgsConstructor;
 
@@ -24,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 public class VenueController {
 
 	private final VenueService venueService;
+	private final VenueCreateFacade venueCreateFacade;
 
 	/**
 	 * 검색어 자동완성 목록 조회 API
@@ -104,5 +111,14 @@ public class VenueController {
 	public ResponseEntity<VenueSearchResponse> searchVenueListById(@PathVariable Long venueId) {
 		VenueSearchResponse venueResponse = venueService.findVenueSearchById(venueId);
 		return ResponseEntity.ok(venueResponse);
+	}
+
+	/**
+	 * 공연장 등록 API
+	 */
+	@PostMapping("/api/venues")
+	public ResponseEntity<VenueCreateResponse> createVenue(@RequestBody VenueCreateRequest venueCreateRequest) {
+		VenueCreateResponse venueCreateResponse = venueCreateFacade.createVenue(venueCreateRequest);
+		return ResponseEntity.status(HttpStatus.CREATED).body(venueCreateResponse);
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/controller/VenueController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/controller/VenueController.java
@@ -25,12 +25,18 @@ public class VenueController {
 
 	private final VenueService venueService;
 
+	/**
+	 * 검색어 자동완성 목록 조회 API
+	 */
 	@GetMapping("/api/search")
 	public ResponseEntity<List<VenueAutocompleteResponse>> searchAutocompleteList(@RequestParam String word) {
 		List<VenueAutocompleteResponse> venues = venueService.searchAutocompleteList(word);
 		return ResponseEntity.ok(venues);
 	}
 
+	/**
+	 * 주변 공연장 목록 조회 API
+	 */
 	@GetMapping("/api/venues/around-venues")
 	public ResponseEntity<List<NearbyVenueResponse>> findNearbyVenues(
 		@RequestParam(required = false) Double latitude,
@@ -59,6 +65,9 @@ public class VenueController {
 		return ResponseEntity.ok(venuePins);
 	}
 
+	/**
+	 * 공연장 목록 조회 - 지도 기반 API
+	 */
 	@GetMapping("/api/venues/map")
 	public ResponseEntity<VenueSearchResponse> findVenuesByLocation(
 		@RequestParam(required = false) Double lowLatitude, @RequestParam(required = false) Double highLatitude,
@@ -88,6 +97,9 @@ public class VenueController {
 		return ResponseEntity.ok(venuesResponse);
 	}
 
+	/**
+	 * 공연장 목록 조회 - 공연장 하나만 검색 API
+	 */
 	@GetMapping("/api/venues/search/{venueId}")
 	public ResponseEntity<VenueSearchResponse> searchVenueListById(@PathVariable Long venueId) {
 		VenueSearchResponse venueResponse = venueService.findVenueSearchById(venueId);

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/request/VenueCreateHour.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/request/VenueCreateHour.java
@@ -1,0 +1,7 @@
+package kr.codesquad.jazzmeet.venue.dto.request;
+
+public record VenueCreateHour(
+	String day,
+	String businessHours
+) {
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/request/VenueCreateLink.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/request/VenueCreateLink.java
@@ -1,0 +1,7 @@
+package kr.codesquad.jazzmeet.venue.dto.request;
+
+public record VenueCreateLink(
+	String type,
+	String url
+) {
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/request/VenueCreateRequest.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/request/VenueCreateRequest.java
@@ -5,7 +5,8 @@ import java.util.List;
 public record VenueCreateRequest(
 	String name,
 	List<Long> imageIds,
-	String address,
+	String roadNameAddress,
+	String lotNumberAddress,
 	String phoneNumber,
 	String description,
 	List<VenueCreateLink> links,

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/request/VenueCreateRequest.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/request/VenueCreateRequest.java
@@ -2,6 +2,9 @@ package kr.codesquad.jazzmeet.venue.dto.request;
 
 import java.util.List;
 
+import lombok.Builder;
+
+@Builder
 public record VenueCreateRequest(
 	String name,
 	List<Long> imageIds,

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/request/VenueCreateRequest.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/request/VenueCreateRequest.java
@@ -1,0 +1,16 @@
+package kr.codesquad.jazzmeet.venue.dto.request;
+
+import java.util.List;
+
+public record VenueCreateRequest(
+	String name,
+	List<Long> imageIds,
+	String address,
+	String phoneNumber,
+	String description,
+	List<VenueCreateLink> links,
+	List<VenueCreateHour> venueHours,
+	double latitude,
+	double longitude
+) {
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/response/VenueCreateResponse.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/response/VenueCreateResponse.java
@@ -1,0 +1,6 @@
+package kr.codesquad.jazzmeet.venue.dto.response;
+
+public record VenueCreateResponse(
+	Long id
+) {
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/DayOfWeek.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/DayOfWeek.java
@@ -1,7 +1,10 @@
 package kr.codesquad.jazzmeet.venue.entity;
 
 import java.time.DateTimeException;
+import java.util.Arrays;
 
+import kr.codesquad.jazzmeet.global.error.CustomException;
+import kr.codesquad.jazzmeet.global.error.statuscode.VenueErrorCode;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -23,5 +26,12 @@ public enum DayOfWeek {
 			throw new DateTimeException("Invalid value for DayOfWeek: " + index);
 		}
 		return ENUMS[index].name;
+	}
+
+	public static DayOfWeek toDayOfWeek(String name) {
+		return Arrays.stream(ENUMS)
+			.filter(dayOfWeek -> dayOfWeek.name.equals(name))
+			.findFirst()
+			.orElseThrow(() -> new CustomException(VenueErrorCode.NOT_FOUND_DAY_OF_WEEK));
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/Link.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/Link.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,4 +27,12 @@ public class Link {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "venue_id")
 	private Venue venue;
+
+	@Builder
+	public Link(Long id, String url, LinkType linkType, Venue venue) {
+		this.id = id;
+		this.url = url;
+		this.linkType = linkType;
+		this.venue = venue;
+	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/Link.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/Link.java
@@ -35,4 +35,9 @@ public class Link {
 		this.linkType = linkType;
 		this.venue = venue;
 	}
+
+	// 연관 관계 편의 메소드
+	public void addVenue(Venue venue) {
+		this.venue = venue;
+	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/LinkType.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/LinkType.java
@@ -19,4 +19,8 @@ public class LinkType {
 	private Long id;
 	@Column(nullable = false, length = 20)
 	private String name;
+
+	public LinkType(String name) {
+		this.name = name;
+	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/Venue.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/Venue.java
@@ -40,11 +40,11 @@ public class Venue {
 	private Long adminId;
 	@Column(length = 500)
 	private String thumbnailUrl;
-	@OneToMany(mappedBy = "venue", cascade = CascadeType.REMOVE, orphanRemoval = true)
+	@OneToMany(mappedBy = "venue", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<VenueImage> images = new ArrayList<>();
-	@OneToMany(mappedBy = "venue", cascade = CascadeType.REMOVE, orphanRemoval = true)
+	@OneToMany(mappedBy = "venue", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Link> links = new ArrayList<>();
-	@OneToMany(mappedBy = "venue", cascade = CascadeType.REMOVE, orphanRemoval = true)
+	@OneToMany(mappedBy = "venue", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<VenueHour> venueHours = new ArrayList<>();
 
 	@Builder
@@ -57,5 +57,18 @@ public class Venue {
 		this.description = description;
 		this.location = location;
 		this.thumbnailUrl = thumbnailUrl;
+	}
+
+	// 연관관계 메서드
+	public void addVenueImage(VenueImage venueImage) {
+		images.add(venueImage);
+	}
+
+	public void addLink(Link link) {
+		links.add(link);
+	}
+
+	public void addVenueHour(VenueHour venueHour) {
+		venueHours.add(venueHour);
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/Venue.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/Venue.java
@@ -59,16 +59,19 @@ public class Venue {
 		this.thumbnailUrl = thumbnailUrl;
 	}
 
-	// 연관관계 메서드
+	// 연관관계 편의 메서드
 	public void addVenueImage(VenueImage venueImage) {
 		images.add(venueImage);
+		venueImage.addVenue(this);
 	}
 
 	public void addLink(Link link) {
 		links.add(link);
+		link.addVenue(this);
 	}
 
 	public void addVenueHour(VenueHour venueHour) {
 		venueHours.add(venueHour);
+		venueHour.addVenue(this);
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/VenueHour.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/VenueHour.java
@@ -44,4 +44,8 @@ public class VenueHour {
 		this.venue = venue;
 		venue.getVenueHours().add(this);
 	}
+
+	public void addVenue(Venue venue) {
+		this.venue = venue;
+	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/VenueImage.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/VenueImage.java
@@ -45,4 +45,8 @@ public class VenueImage {
 		this.image = image;
 		venue.getImages().add(this);
 	}
+
+	public void addVenue(Venue venue) {
+		this.venue = venue;
+	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/mapper/VenueMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/mapper/VenueMapper.java
@@ -3,12 +3,14 @@ package kr.codesquad.jazzmeet.venue.mapper;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.locationtech.jts.geom.Point;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 import kr.codesquad.jazzmeet.venue.dto.ShowInfo;
 import kr.codesquad.jazzmeet.venue.dto.VenueSearch;
+import kr.codesquad.jazzmeet.venue.dto.request.VenueCreateRequest;
 import kr.codesquad.jazzmeet.venue.dto.response.NearbyVenueResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueAutocompleteResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueDetailResponse;
@@ -79,4 +81,6 @@ public interface VenueMapper {
 	@Mapping(target = "venueHours", source = "venueHours")
 	VenueDetail toVenueDatail(Integer dummy, Venue venue,
 		List<VenueDetailImage> images, List<VenueDetailLink> links, List<VenueDetailVenueHour> venueHours);
+
+	Venue toVenue(VenueCreateRequest venueCreateRequest, Point location, String thumbnailUrl);
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/LinkTypeRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/LinkTypeRepository.java
@@ -1,0 +1,14 @@
+package kr.codesquad.jazzmeet.venue.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import kr.codesquad.jazzmeet.venue.entity.LinkType;
+
+@Repository
+public interface LinkTypeRepository extends JpaRepository<LinkType, Long> {
+
+	Optional<LinkType> findByName(String name);
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/service/LinkTypeService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/service/LinkTypeService.java
@@ -1,0 +1,21 @@
+package kr.codesquad.jazzmeet.venue.service;
+
+import org.springframework.stereotype.Service;
+
+import kr.codesquad.jazzmeet.global.error.CustomException;
+import kr.codesquad.jazzmeet.global.error.statuscode.VenueErrorCode;
+import kr.codesquad.jazzmeet.venue.entity.LinkType;
+import kr.codesquad.jazzmeet.venue.repository.LinkTypeRepository;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class LinkTypeService {
+
+	private final LinkTypeRepository linkTypeRepository;
+
+	public LinkType findByName(String name) {
+		return linkTypeRepository.findByName(name)
+			.orElseThrow(() -> new CustomException(VenueErrorCode.NOT_FOUND_LINK_TYPE));
+	}
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueCreateFacade.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueCreateFacade.java
@@ -1,0 +1,81 @@
+package kr.codesquad.jazzmeet.venue.service;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.locationtech.jts.geom.Point;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.codesquad.jazzmeet.image.entity.Image;
+import kr.codesquad.jazzmeet.image.service.ImageService;
+import kr.codesquad.jazzmeet.venue.dto.request.VenueCreateHour;
+import kr.codesquad.jazzmeet.venue.dto.request.VenueCreateLink;
+import kr.codesquad.jazzmeet.venue.dto.request.VenueCreateRequest;
+import kr.codesquad.jazzmeet.venue.dto.response.VenueCreateResponse;
+import kr.codesquad.jazzmeet.venue.entity.DayOfWeek;
+import kr.codesquad.jazzmeet.venue.entity.Link;
+import kr.codesquad.jazzmeet.venue.entity.LinkType;
+import kr.codesquad.jazzmeet.venue.entity.Venue;
+import kr.codesquad.jazzmeet.venue.entity.VenueHour;
+import kr.codesquad.jazzmeet.venue.entity.VenueImage;
+import kr.codesquad.jazzmeet.venue.mapper.VenueMapper;
+import kr.codesquad.jazzmeet.venue.util.VenueUtil;
+import lombok.RequiredArgsConstructor;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class VenueCreateFacade {
+
+	private static final int THUMBNAIL_IMAGE_INDEX = 0;
+
+	private final VenueService venueService;
+	private final ImageService imageService;
+	private final LinkTypeService linkTypeService;
+
+	public VenueCreateResponse createVenue(VenueCreateRequest venueCreateRequest) {
+		Point location = VenueUtil.createPoint(venueCreateRequest.latitude(), venueCreateRequest.longitude());
+
+		List<Long> imageIds = venueCreateRequest.imageIds();
+		Image thumbnailImage = imageService.findById(imageIds.get(THUMBNAIL_IMAGE_INDEX));
+
+		Venue venue = VenueMapper.INSTANCE.toVenue(venueCreateRequest, location, thumbnailImage.getUrl());
+
+		AtomicLong imageOrder = new AtomicLong(0L);
+		imageIds.forEach(imageId -> {
+			Image image = imageService.findById(imageId);
+			VenueImage venueImage = VenueImage.builder()
+				.imageOrder(imageOrder.incrementAndGet())
+				.venue(venue)
+				.image(image)
+				.build();
+			venue.addVenueImage(venueImage);
+		});
+
+		List<VenueCreateLink> links = venueCreateRequest.links();
+		links.forEach(venueCreateLink -> {
+			String type = venueCreateLink.type();
+			LinkType linkType = linkTypeService.findByName(type);
+			Link link = Link.builder()
+				.url(venueCreateLink.url())
+				.linkType(linkType)
+				.venue(venue)
+				.build();
+			venue.addLink(link);
+		});
+
+		List<VenueCreateHour> venueHours = venueCreateRequest.venueHours();
+		venueHours.forEach(venueCreateHour -> {
+			VenueHour venueHour = VenueHour.builder()
+				.day(DayOfWeek.toDayOfWeek(venueCreateHour.day()))
+				.businessHour(venueCreateHour.businessHours())
+				.venue(venue)
+				.build();
+			venue.addVenueHour(venueHour);
+		});
+
+		Venue savedVenue = venueService.save(venue);
+		return new VenueCreateResponse(savedVenue.getId());
+	}
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueFacade.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueFacade.java
@@ -70,7 +70,6 @@ public class VenueFacade {
 			Image image = imageService.findById(imageId);
 			VenueImage venueImage = VenueImage.builder()
 				.imageOrder(imageOrder.incrementAndGet())
-				.venue(venue)
 				.image(image)
 				.build();
 			venue.addVenueImage(venueImage);
@@ -84,7 +83,6 @@ public class VenueFacade {
 			Link link = Link.builder()
 				.url(venueCreateLink.url())
 				.linkType(linkType)
-				.venue(venue)
 				.build();
 			venue.addLink(link);
 		});
@@ -95,7 +93,6 @@ public class VenueFacade {
 			VenueHour venueHour = VenueHour.builder()
 				.day(DayOfWeek.toDayOfWeek(venueCreateHour.day()))
 				.businessHour(venueCreateHour.businessHours())
-				.venue(venue)
 				.build();
 			venue.addVenueHour(venueHour);
 		});

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueFacade.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueFacade.java
@@ -60,7 +60,7 @@ public class VenueFacade {
 
 	private void validateImagesCount(List<Long> imageIds) {
 		if (imageIds.size() > 10) {
-			throw new CustomException(ImageErrorCode.NOT_FOUND_IMAGE);
+			throw new CustomException(ImageErrorCode.IMAGE_LIMIT_EXCEEDED);
 		}
 	}
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueFacade.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueFacade.java
@@ -7,6 +7,8 @@ import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import kr.codesquad.jazzmeet.global.error.CustomException;
+import kr.codesquad.jazzmeet.global.error.statuscode.ImageErrorCode;
 import kr.codesquad.jazzmeet.image.entity.Image;
 import kr.codesquad.jazzmeet.image.service.ImageService;
 import kr.codesquad.jazzmeet.venue.dto.request.VenueCreateHour;
@@ -39,6 +41,7 @@ public class VenueFacade {
 		Point location = VenueUtil.createPoint(venueCreateRequest.latitude(), venueCreateRequest.longitude());
 
 		List<Long> imageIds = venueCreateRequest.imageIds();
+		validateImagesCount(imageIds);
 		Image thumbnailImage = imageService.findById(imageIds.get(THUMBNAIL_IMAGE_INDEX));
 
 		Venue venue = VenueMapper.INSTANCE.toVenue(venueCreateRequest, location, thumbnailImage.getUrl());
@@ -53,6 +56,12 @@ public class VenueFacade {
 
 		Venue savedVenue = venueService.save(venue);
 		return new VenueCreateResponse(savedVenue.getId());
+	}
+
+	private void validateImagesCount(List<Long> imageIds) {
+		if (imageIds.size() > 10) {
+			throw new CustomException(ImageErrorCode.NOT_FOUND_IMAGE);
+		}
 	}
 
 	private void addVenueImages(Venue venue, List<Long> imageIds) {

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueService.java
@@ -155,4 +155,8 @@ public class VenueService {
 		return VenueMapper.INSTANCE.toVenueSearchResponse(venueSearchList, venueSearchList.size(),
 			PAGE_NUMBER_OFFSET, PAGE_NUMBER_OFFSET);
 	}
+
+	public Venue save(Venue venue) {
+		return venueRepository.save(venue);
+	}
 }

--- a/be/src/test/java/kr/codesquad/jazzmeet/image/service/ImageServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/image/service/ImageServiceTest.java
@@ -40,7 +40,7 @@ class ImageServiceTest extends IntegrationTestSupport {
 		ImageIdsResponse imageIdsResponse = imageService.saveImages(imageUrls);
 
 		// then
-		assertThat(imageIdsResponse.getIds()).hasSize(imageUrls.size())
+		assertThat(imageIdsResponse.ids()).hasSize(imageUrls.size())
 			.containsExactly(1L, 2L, 3L);
 	}
 

--- a/be/src/test/java/kr/codesquad/jazzmeet/image/service/ImageServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/image/service/ImageServiceTest.java
@@ -40,8 +40,7 @@ class ImageServiceTest extends IntegrationTestSupport {
 		ImageIdsResponse imageIdsResponse = imageService.saveImages(imageUrls);
 
 		// then
-		assertThat(imageIdsResponse.ids()).hasSize(imageUrls.size())
-			.containsExactly(1L, 2L, 3L);
+		assertThat(imageIdsResponse.ids()).hasSize(imageUrls.size());
 	}
 
 	@Test
@@ -63,7 +62,7 @@ class ImageServiceTest extends IntegrationTestSupport {
 	@DisplayName("존재하지 않는 아이디로 이미지를 삭제하려 하면 삭제되지 않는다")
 	void deleteImageWrongId() {
 		// given
-		Long wrongId = 3L;
+		Long wrongId = -1L;
 
 		// when then
 		assertThatThrownBy(() -> imageService.deleteImage(wrongId))

--- a/be/src/test/java/kr/codesquad/jazzmeet/show/repository/ShowRepositoryTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/show/repository/ShowRepositoryTest.java
@@ -35,9 +35,9 @@ class ShowRepositoryTest extends IntegrationTestSupport {
 
 		Venue venue = VenueFixture.createVenue("부기우기", "경기도 고양시");
 		Show show1 = ShowFixture.createShow("트리오", LocalDateTime.of(2023, 11, 3, 18, 00),
-			LocalDateTime.of(2023, 11, 3, 20, 0), venue);
+			LocalDateTime.of(2023, 11, 3, 20, 00), venue);
 		Show show2 = ShowFixture.createShow("퀄텟", LocalDateTime.of(2023, 11, 3, 20, 00),
-			LocalDateTime.of(2023, 11, 3, 22, 0), venue);
+			LocalDateTime.of(2023, 11, 3, 22, 00), venue);
 		showRepository.saveAll(List.of(show1, show2));
 
 		//when
@@ -59,11 +59,11 @@ class ShowRepositoryTest extends IntegrationTestSupport {
 		Venue venue2 = VenueFixture.createVenue("클럽에반스", "경기도 고양시");
 
 		Show show1 = ShowFixture.createShow("트리오", LocalDateTime.of(2023, 11, 1, 18, 00),
-			LocalDateTime.of(2023, 11, 1, 20, 0), venue1);
+			LocalDateTime.of(2023, 11, 1, 20, 00), venue1);
 		Show show2 = ShowFixture.createShow("트리오", LocalDateTime.of(2023, 11, 10, 18, 00),
-			LocalDateTime.of(2023, 11, 10, 20, 0), venue1);
+			LocalDateTime.of(2023, 11, 10, 20, 00), venue1);
 		Show show3 = ShowFixture.createShow("트리오", LocalDateTime.of(2023, 11, 20, 18, 00),
-			LocalDateTime.of(2023, 11, 20, 20, 0), venue2);
+			LocalDateTime.of(2023, 11, 20, 20, 00), venue2);
 		showRepository.saveAll(List.of(show1, show2, show3));
 
 	    //when

--- a/be/src/test/java/kr/codesquad/jazzmeet/show/repository/ShowRepositoryTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/show/repository/ShowRepositoryTest.java
@@ -35,9 +35,9 @@ class ShowRepositoryTest extends IntegrationTestSupport {
 
 		Venue venue = VenueFixture.createVenue("부기우기", "경기도 고양시");
 		Show show1 = ShowFixture.createShow("트리오", LocalDateTime.of(2023, 11, 3, 18, 00),
-			LocalDateTime.of(2023, 11, 3, 20, 00), venue);
+			LocalDateTime.of(2023, 11, 3, 20, 0), venue);
 		Show show2 = ShowFixture.createShow("퀄텟", LocalDateTime.of(2023, 11, 3, 20, 00),
-			LocalDateTime.of(2023, 11, 3, 22, 00), venue);
+			LocalDateTime.of(2023, 11, 3, 22, 0), venue);
 		showRepository.saveAll(List.of(show1, show2));
 
 		//when
@@ -59,11 +59,11 @@ class ShowRepositoryTest extends IntegrationTestSupport {
 		Venue venue2 = VenueFixture.createVenue("클럽에반스", "경기도 고양시");
 
 		Show show1 = ShowFixture.createShow("트리오", LocalDateTime.of(2023, 11, 1, 18, 00),
-			LocalDateTime.of(2023, 11, 1, 20, 00), venue1);
+			LocalDateTime.of(2023, 11, 1, 20, 0), venue1);
 		Show show2 = ShowFixture.createShow("트리오", LocalDateTime.of(2023, 11, 10, 18, 00),
-			LocalDateTime.of(2023, 11, 10, 20, 00), venue1);
+			LocalDateTime.of(2023, 11, 10, 20, 0), venue1);
 		Show show3 = ShowFixture.createShow("트리오", LocalDateTime.of(2023, 11, 20, 18, 00),
-			LocalDateTime.of(2023, 11, 20, 20, 00), venue2);
+			LocalDateTime.of(2023, 11, 20, 20, 0), venue2);
 		showRepository.saveAll(List.of(show1, show2, show3));
 
 	    //when

--- a/be/src/test/java/kr/codesquad/jazzmeet/venue/repository/VenueQueryRepositoryTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/venue/repository/VenueQueryRepositoryTest.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,8 +47,12 @@ class VenueQueryRepositoryTest extends IntegrationTestSupport {
 	@Autowired
 	VenueImageRepository venueImageRepository;
 
-	@Autowired
-	VenueHourRepository venueHourRepository;
+	@AfterEach
+	void dbClean() {
+		venueImageRepository.deleteAllInBatch();
+		showRepository.deleteAllInBatch();
+		venueRepository.deleteAllInBatch();
+	}
 
 	@DisplayName("이름에 검색어가 포함되어 있는 공연장 정보 리스트를 조회한다.")
 	@Test

--- a/be/src/test/java/kr/codesquad/jazzmeet/venue/service/VenueFacadeTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/venue/service/VenueFacadeTest.java
@@ -1,0 +1,92 @@
+package kr.codesquad.jazzmeet.venue.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import kr.codesquad.jazzmeet.IntegrationTestSupport;
+import kr.codesquad.jazzmeet.fixture.ImageFixture;
+import kr.codesquad.jazzmeet.global.error.CustomException;
+import kr.codesquad.jazzmeet.image.entity.Image;
+import kr.codesquad.jazzmeet.image.repository.ImageRepository;
+import kr.codesquad.jazzmeet.venue.dto.request.VenueCreateHour;
+import kr.codesquad.jazzmeet.venue.dto.request.VenueCreateLink;
+import kr.codesquad.jazzmeet.venue.dto.request.VenueCreateRequest;
+import kr.codesquad.jazzmeet.venue.dto.response.VenueCreateResponse;
+import kr.codesquad.jazzmeet.venue.entity.LinkType;
+import kr.codesquad.jazzmeet.venue.repository.LinkTypeRepository;
+
+class VenueFacadeTest extends IntegrationTestSupport {
+
+	@Autowired
+	VenueFacade venueFacade;
+
+	@Autowired
+	ImageRepository imageRepository;
+
+	@Autowired
+	LinkTypeRepository linkTypeRepository;
+
+	@Test
+	@DisplayName("공연장 데이터를 입력 받아서 공연장을 생성한다")
+	void createVenue() {
+	    // given
+		Image image1 = ImageFixture.createImage("url1");
+		Image image2 = ImageFixture.createImage("url2");
+		List<Image> images = imageRepository.saveAll(List.of(image1, image2));
+
+		LinkType naverMapLinkType = new LinkType("naverMap");
+		LinkType instagramLinkType = new LinkType("instagram");
+		linkTypeRepository.saveAll(List.of(naverMapLinkType, instagramLinkType));
+
+		VenueCreateLink link1 = new VenueCreateLink("naverMap", "www.naverMap.com");
+		VenueCreateLink link2 = new VenueCreateLink("instagram", "www.instagram.com");
+
+		VenueCreateHour venueHour1 = new VenueCreateHour("월요일", "휴무");
+		VenueCreateHour venueHour2 = new VenueCreateHour("화요일", "휴무");
+		VenueCreateHour venueHour3 = new VenueCreateHour("수요일", "휴무");
+
+		VenueCreateRequest venueCreateRequest = VenueCreateRequest.builder()
+			.name("공연장")
+			.imageIds(List.of(images.get(0).getId(), images.get(1).getId()))
+			.roadNameAddress("도로명 주소")
+			.lotNumberAddress("지번 주소")
+			.phoneNumber("010-1234-5678")
+			.description("공연장 설명")
+			.links(List.of(link1, link2))
+			.venueHours(List.of(venueHour1, venueHour2, venueHour3))
+			.latitude(37.50049856339995)
+			.longitude(127.0249505634053)
+			.build();
+
+		// when
+		VenueCreateResponse response = venueFacade.createVenue(venueCreateRequest);
+
+		// then
+		assertThat(response).extracting("id").isNotNull();
+	}
+
+	@Test
+	@DisplayName("이미지 개수가 10개가 넘으면 공연장을 생성할 수 없다")
+	void createVenueWithManyImage() {
+		// given
+		VenueCreateRequest venueCreateRequest = VenueCreateRequest.builder()
+			.name("공연장")
+			.imageIds(List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L))
+			.roadNameAddress("도로명 주소")
+			.lotNumberAddress("지번 주소")
+			.phoneNumber("010-1234-5678")
+			.description("공연장 설명")
+			.latitude(37.50049856339995)
+			.longitude(127.0249505634053)
+			.build();
+
+		// when then
+		assertThatThrownBy(() -> venueFacade.createVenue(venueCreateRequest))
+			.isInstanceOf(CustomException.class);
+	}
+}

--- a/be/src/test/java/kr/codesquad/jazzmeet/venue/service/VenueFacadeTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/venue/service/VenueFacadeTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 import kr.codesquad.jazzmeet.IntegrationTestSupport;
 import kr.codesquad.jazzmeet.fixture.ImageFixture;
@@ -20,6 +21,7 @@ import kr.codesquad.jazzmeet.venue.dto.response.VenueCreateResponse;
 import kr.codesquad.jazzmeet.venue.entity.LinkType;
 import kr.codesquad.jazzmeet.venue.repository.LinkTypeRepository;
 
+@Transactional
 class VenueFacadeTest extends IntegrationTestSupport {
 
 	@Autowired

--- a/be/src/test/java/kr/codesquad/jazzmeet/venue/service/VenueServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/venue/service/VenueServiceTest.java
@@ -48,6 +48,7 @@ class VenueServiceTest extends IntegrationTestSupport {
 
 	@AfterEach
 	void dbClean() {
+		venueImageRepository.deleteAllInBatch();
 		venueRepository.deleteAllInBatch();
 	}
 


### PR DESCRIPTION
## What is this PR? 👓
- 공연장 등록 API 구현
- 테스트 코드 작성

## Key changes 🔑
- VenueFacade 클래스 구현
    - 각 Service는 하나의 도메인에 관련된 책임만 가지도록 하고
    - 여러 Service를 참조해야 하는 경우 Facade 클래스에서 참조해서 사용하도록 구현했습니다.
- Venue에서 VenueImage, Link, VenueHour의 생성과 삭제를 관리할 수 있도록 cascadeType을 ALL로 변경했습니다.
    - Venue를 생성, 삭제 하면 VenueImage, Link, VenueHour도 같이 생성, 삭제 됩니다.

## To reviewers 👋
- VenueFacadeTest에서 Venue를 생성하고 데이터를 초기화하기 위해서는 연관관계를 가진 테이블들을 모두 삭제해줘야 하는데 Link 테이블은 LinkRepository를 사용해서 관리하지 않아서 삭제할 수 없는 문제가 생겨서 @Transactinal을 클래스에 붙여서 초기화하도록 했는데 @Transactional을 붙이는 게 좋은 방법인지는 고민이 됩니다.
- 그래서 테스트 메서드 실행 시마다 DB 테이블을 모두 삭제하는 메서드를 만드는 것도 좋은 것 같아요