### PR TITLE
방향키로 검색어 목록 선택 기능

### DIFF
--- a/fe/user/src/components/SearchBox/SuggestionBox/SuggestionItem.tsx
+++ b/fe/user/src/components/SearchBox/SuggestionBox/SuggestionItem.tsx
@@ -5,10 +5,15 @@ import { SearchSuggestion } from '~/types/api.types';
 
 type Props = {
   suggestion: SearchSuggestion;
+  active: boolean;
   onClose: () => void;
 };
 
-export const SuggestionItem: React.FC<Props> = ({ suggestion, onClose }) => {
+export const SuggestionItem: React.FC<Props> = ({
+  suggestion,
+  active,
+  onClose,
+}) => {
   const navigate = useNavigate();
 
   const navigateToVenueDetail = () => {
@@ -17,7 +22,7 @@ export const SuggestionItem: React.FC<Props> = ({ suggestion, onClose }) => {
   };
 
   return (
-    <StyledSuggestionItem onClick={navigateToVenueDetail}>
+    <StyledSuggestionItem onClick={navigateToVenueDetail} $active={active}>
       <RoomRoundedIcon />
       <StyledInformation>
         <h4>{suggestion.name}</h4>
@@ -27,10 +32,11 @@ export const SuggestionItem: React.FC<Props> = ({ suggestion, onClose }) => {
   );
 };
 
-const StyledSuggestionItem = styled.li`
+const StyledSuggestionItem = styled.li<{ $active: boolean}>`
   padding: 12px 16px;
   display: flex;
   gap: 8px;
+  ${({ $active }) => $active && `background-color: #f5f5f5;`}
 
   &:hover,
   &:focus {

--- a/fe/user/src/components/SearchBox/SuggestionBox/SuggestionItem.tsx
+++ b/fe/user/src/components/SearchBox/SuggestionBox/SuggestionItem.tsx
@@ -32,7 +32,7 @@ export const SuggestionItem: React.FC<Props> = ({
   );
 };
 
-const StyledSuggestionItem = styled.li<{ $active: boolean}>`
+const StyledSuggestionItem = styled.li<{ $active: boolean }>`
   padding: 12px 16px;
   display: flex;
   gap: 8px;

--- a/fe/user/src/components/SearchBox/SuggestionBox/index.tsx
+++ b/fe/user/src/components/SearchBox/SuggestionBox/index.tsx
@@ -7,6 +7,7 @@ type Props = {
   suggestions: SearchSuggestion[];
   open: boolean;
   searchBoxRef: React.RefObject<HTMLDivElement>;
+  activeIndex: number;
   onClose: () => void;
 };
 
@@ -14,6 +15,7 @@ export const SuggestionBox: React.FC<Props> = ({
   suggestions,
   open,
   searchBoxRef,
+  activeIndex,
   onClose
 }) => {
   useEffect(() => {
@@ -37,8 +39,8 @@ export const SuggestionBox: React.FC<Props> = ({
   return (
     <StyledSuggestionBox $open={open}>
       <StyledSuggestionList>
-        {suggestions.map((suggestion) => (
-          <SuggestionItem key={suggestion.id} suggestion={suggestion} onClose={onClose} />
+        {suggestions.map((suggestion, index) => (
+          <SuggestionItem key={suggestion.id} suggestion={suggestion} onClose={onClose} active={index === activeIndex} />
         ))}
       </StyledSuggestionList>
     </StyledSuggestionBox>

--- a/fe/user/src/components/SearchBox/index.tsx
+++ b/fe/user/src/components/SearchBox/index.tsx
@@ -19,44 +19,17 @@ export const SearchBox: React.FC = () => {
     useState<number>(-1);
   const searchBoxRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (searchText.trim().length === 0) {
-      setSearchSuggestions([]);
-      return;
-    }
-
-    const timer = setTimeout(async () => {
-      const suggestions = await getSearchSuggestions(searchText);
-      setSearchSuggestions(suggestions);
-    }, 120);
-
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [searchText]);
-
-  useEffect(() => {
-    setIsSuggestionBoxOpen(searchSuggestions.length > 0);
-  }, [searchSuggestions]);
-
-  useEffect(() => {
-    if (isSuggestionBoxOpen === false) {
-      setActiveSuggestionIndex(-1);
-    }
-  }, [isSuggestionBoxOpen]);
-
   const query = new URLSearchParams(queryString);
   const word = query.get('word');
+  const isSearchTextEmpty = searchText.trim().length === 0;
 
   const showSuggestionBox = () => setIsSuggestionBoxOpen(true);
   const hideSuggestionBox = () => setIsSuggestionBoxOpen(false);
 
   const onInputBaseFocus = () => {
-    if (searchText.trim().length === 0) {
-      return;
+    if (!isSearchTextEmpty) {
+      showSuggestionBox();
     }
-
-    showSuggestionBox();
   };
 
   const onSearchTextSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -69,7 +42,7 @@ export const SearchBox: React.FC = () => {
       return;
     }
 
-    if (searchText.trim().length > 0) {
+    if (!isSearchTextEmpty) {
       navigate(`/map?word=${searchText}`);
       hideSuggestionBox();
     }
@@ -93,6 +66,32 @@ export const SearchBox: React.FC = () => {
       );
     }
   };
+
+  useEffect(() => {
+    if (isSearchTextEmpty) {
+      setSearchSuggestions([]);
+      return;
+    }
+
+    const timer = setTimeout(async () => {
+      const suggestions = await getSearchSuggestions(searchText);
+      setSearchSuggestions(suggestions);
+    }, 120);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [searchText, isSearchTextEmpty]);
+
+  useEffect(() => {
+    setIsSuggestionBoxOpen(searchSuggestions.length > 0);
+  }, [searchSuggestions]);
+
+  useEffect(() => {
+    if (isSuggestionBoxOpen === false) {
+      setActiveSuggestionIndex(-1);
+    }
+  }, [isSuggestionBoxOpen]);
 
   return (
     <StyledSearchBox id="search-box" ref={searchBoxRef}>

--- a/fe/user/src/components/SearchBox/index.tsx
+++ b/fe/user/src/components/SearchBox/index.tsx
@@ -43,18 +43,21 @@ export const SearchBox: React.FC = () => {
     if (isSuggestionBoxOpen === false) {
       setActiveSuggestionIndex(-1);
     }
-  }, [isSuggestionBoxOpen])
+  }, [isSuggestionBoxOpen]);
 
   const query = new URLSearchParams(queryString);
   const word = query.get('word');
 
-  const showSuggestionBox = () => {
+  const showSuggestionBox = () => setIsSuggestionBoxOpen(true);
+  const hideSuggestionBox = () => setIsSuggestionBoxOpen(false);
+
+  const onInputBaseFocus = () => {
     if (searchText.trim().length === 0) {
       return;
     }
-    setIsSuggestionBoxOpen(true);
+
+    showSuggestionBox();
   };
-  const hideSuggestionBox = () => setIsSuggestionBoxOpen(false);
 
   const onSearchTextSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -113,7 +116,7 @@ export const SearchBox: React.FC = () => {
           value={searchText || word || ''}
           onChange={(e) => setSearchText(e.target.value)}
           onKeyDown={changeActiveSuggstion}
-          onFocus={showSuggestionBox}
+          onFocus={onInputBaseFocus}
         />
         <IconButton type="button" sx={{ p: '10px' }} aria-label="search">
           <SearchIcon />

--- a/fe/user/src/components/SearchBox/index.tsx
+++ b/fe/user/src/components/SearchBox/index.tsx
@@ -15,6 +15,8 @@ export const SearchBox: React.FC = () => {
     SearchSuggestion[]
   >([]);
   const [isSuggestionBoxOpen, setIsSuggestionBoxOpen] = useState(false);
+  const [activeSuggestionIndex, setActiveSuggestionIndex] =
+    useState<number>(-1);
   const searchBoxRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -57,11 +59,23 @@ export const SearchBox: React.FC = () => {
     }
   };
 
+  const onArrowKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      setActiveSuggestionIndex((asi) =>
+        asi === searchSuggestions.length - 1 ? -1 : asi + 1,
+      );
+      return;
+    }
+
+    if (e.key === 'ArrowUp') {
+      setActiveSuggestionIndex((asi) =>
+        asi === -1 ? searchSuggestions.length - 1 : asi - 1,
+      );
+    }
+  };
+
   return (
-    <StyledSearchBox
-      id="search-box"
-      ref={searchBoxRef}
-    >
+    <StyledSearchBox id="search-box" ref={searchBoxRef}>
       <Paper
         component="form"
         onSubmit={onSearchTextSubmit}
@@ -81,6 +95,7 @@ export const SearchBox: React.FC = () => {
           autoComplete="off"
           value={searchText || word || ''}
           onChange={(e) => setSearchText(e.target.value)}
+          onKeyDown={onArrowKeyDown}
           onFocus={showSuggestionBox}
         />
         <IconButton type="button" sx={{ p: '10px' }} aria-label="search">
@@ -92,6 +107,7 @@ export const SearchBox: React.FC = () => {
         suggestions={searchSuggestions}
         open={isSuggestionBoxOpen}
         searchBoxRef={searchBoxRef}
+        activeIndex={activeSuggestionIndex}
         onClose={hideSuggestionBox}
       />
     </StyledSearchBox>

--- a/fe/user/src/components/SearchBox/index.tsx
+++ b/fe/user/src/components/SearchBox/index.tsx
@@ -61,6 +61,8 @@ export const SearchBox: React.FC = () => {
 
   const onArrowKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'ArrowDown') {
+      e.preventDefault();
+
       setActiveSuggestionIndex((asi) =>
         asi === searchSuggestions.length - 1 ? -1 : asi + 1,
       );
@@ -68,6 +70,8 @@ export const SearchBox: React.FC = () => {
     }
 
     if (e.key === 'ArrowUp') {
+      e.preventDefault();
+
       setActiveSuggestionIndex((asi) =>
         asi === -1 ? searchSuggestions.length - 1 : asi - 1,
       );

--- a/fe/user/src/components/SearchBox/index.tsx
+++ b/fe/user/src/components/SearchBox/index.tsx
@@ -39,6 +39,12 @@ export const SearchBox: React.FC = () => {
     setIsSuggestionBoxOpen(searchSuggestions.length > 0);
   }, [searchSuggestions]);
 
+  useEffect(() => {
+    if (isSuggestionBoxOpen === false) {
+      setActiveSuggestionIndex(-1);
+    }
+  }, [isSuggestionBoxOpen])
+
   const query = new URLSearchParams(queryString);
   const word = query.get('word');
 
@@ -53,13 +59,20 @@ export const SearchBox: React.FC = () => {
   const onSearchTextSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
+    if (activeSuggestionIndex !== -1) {
+      const { id } = searchSuggestions[activeSuggestionIndex];
+      navigate(`/map?venueId=${id}`);
+      hideSuggestionBox();
+      return;
+    }
+
     if (searchText.trim().length > 0) {
       navigate(`/map?word=${searchText}`);
       hideSuggestionBox();
     }
   };
 
-  const onArrowKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const changeActiveSuggstion = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'ArrowDown') {
       e.preventDefault();
 
@@ -99,7 +112,7 @@ export const SearchBox: React.FC = () => {
           autoComplete="off"
           value={searchText || word || ''}
           onChange={(e) => setSearchText(e.target.value)}
-          onKeyDown={onArrowKeyDown}
+          onKeyDown={changeActiveSuggstion}
           onFocus={showSuggestionBox}
         />
         <IconButton type="button" sx={{ p: '10px' }} aria-label="search">


### PR DESCRIPTION
## What is this PR? 👓
검색창에서 위,아래 방향키로 검색어 자동완성 목록을 선택하는 기능을 구현하는 작업입니다.
선택한 목록에서 엔터를 누르면 해당 공연장으로 이동합니다.

검색창에서 방향키로 목록으로 이동하고 해당 목록을 선택하는 기능은 사용자 편의성을 위해 반드시 필요한 기능입니다.

## Key changes 🔑
- 검색창 keydown 이벤트 핸들러 구현(changeActiveSuggstion)
- 위,아래 방향키 입력 이벤트의 기본 동작으로 키보드 커서가 앞, 뒤로 이동하는 현상이 발생해 preventDefault 호출
- 선택된 검색어 목록이 있는 경우, 해당 공연장으로 검색
- 검색어 목록이 닫히는 경우 선택된 검색어 index 초기화

## To reviewers 👋
- 검색창에 대한 키보드 이벤트가 3개(onSubmit, onChange, onKeydown)로 분산되어 파악하기 힘들 것 같아 우려됩니다.
- 검색 후 검색어 목록을 다시 열려면 바깥을 클릭했다가 input을 다시 클릭해야합니다. 검색할 때 input에 커서가 남아있기 때문인데, 번거롭게 느껴집니다. input 요소를 ref에 할당하고 blur()를 호출하면 될 것 같습니다만, InputBase 컴포넌트가 input을 div로 감싼 JSX를 반환하기 때문에 깔끔하게 적용하기가 어렵네요.

  ```TypeScript
  (inputRef.current?.children.item(0) as HTMLElement).blur()
  ```