### PR TITLE
문의 글 등록

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/InquiryErrorCode.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/InquiryErrorCode.java
@@ -7,7 +7,8 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public enum InquiryErrorCode implements StatusCode {
 	NO_MATCH_VALUE(HttpStatus.NOT_FOUND, "해당하는 종류가 없습니다."),
-	NOT_FOUND_INQUIRY(HttpStatus.NOT_FOUND, "해당하는 문의가 없습니다.");
+	NOT_FOUND_INQUIRY(HttpStatus.NOT_FOUND, "해당하는 문의가 없습니다."),
+	NO_SUCH_ALGORITHM(HttpStatus.NOT_FOUND, "해당하는 알고리즘이 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/controller/InquiryController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/controller/InquiryController.java
@@ -1,13 +1,18 @@
 package kr.codesquad.jazzmeet.inquiry.controller;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.constraints.Min;
+import kr.codesquad.jazzmeet.inquiry.dto.request.InquirySaveRequest;
 import kr.codesquad.jazzmeet.inquiry.dto.response.InquiryDetailResponse;
+import kr.codesquad.jazzmeet.inquiry.dto.response.InquirySaveResponse;
 import kr.codesquad.jazzmeet.inquiry.dto.response.InquirySearchResponse;
 import kr.codesquad.jazzmeet.inquiry.service.InquiryService;
 import lombok.RequiredArgsConstructor;
@@ -38,5 +43,15 @@ public class InquiryController {
 		InquiryDetailResponse inquiry = inquiryService.getInquiryDetail(inquiryId);
 
 		return ResponseEntity.ok(inquiry);
+	}
+
+	/**
+	 * 문의 글 등록 API
+	 */
+	@PostMapping("/api/inquiries")
+	public ResponseEntity<InquirySaveResponse> save(@RequestBody InquirySaveRequest inquirySaveRequest) {
+		InquirySaveResponse inquiry = inquiryService.save(inquirySaveRequest);
+
+		return ResponseEntity.status(HttpStatus.CREATED).body(inquiry);
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/controller/InquiryController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/controller/InquiryController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import kr.codesquad.jazzmeet.inquiry.dto.request.InquirySaveRequest;
 import kr.codesquad.jazzmeet.inquiry.dto.response.InquiryDetailResponse;
@@ -49,7 +50,7 @@ public class InquiryController {
 	 * 문의 글 등록 API
 	 */
 	@PostMapping("/api/inquiries")
-	public ResponseEntity<InquirySaveResponse> save(@RequestBody InquirySaveRequest inquirySaveRequest) {
+	public ResponseEntity<InquirySaveResponse> save(@RequestBody @Valid InquirySaveRequest inquirySaveRequest) {
 		InquirySaveResponse inquiry = inquiryService.save(inquirySaveRequest);
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(inquiry);

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/controller/InquiryController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/controller/InquiryController.java
@@ -34,7 +34,7 @@ public class InquiryController {
 	 * 문의 글 상세 조회 API
 	 */
 	@GetMapping("/api/inquiries/{inquiryId}")
-	public ResponseEntity<?> getInquiryDetail(@PathVariable Long inquiryId) {
+	public ResponseEntity<InquiryDetailResponse> getInquiryDetail(@PathVariable Long inquiryId) {
 		InquiryDetailResponse inquiry = inquiryService.getInquiryDetail(inquiryId);
 
 		return ResponseEntity.ok(inquiry);

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/dto/request/InquirySaveRequest.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/dto/request/InquirySaveRequest.java
@@ -1,9 +1,18 @@
 package kr.codesquad.jazzmeet.inquiry.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
 public record InquirySaveRequest(
+	@NotNull
 	String category,
+	@Size(max = 8)
+	@NotNull
 	String nickname,
+	@Size(max = 20)
+	@NotNull
 	String password,
+	@NotNull
 	String content
 ) {
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/dto/request/InquirySaveRequest.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/dto/request/InquirySaveRequest.java
@@ -2,7 +2,9 @@ package kr.codesquad.jazzmeet.inquiry.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 
+@Builder
 public record InquirySaveRequest(
 	@NotNull
 	String category,

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/dto/request/InquirySaveRequest.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/dto/request/InquirySaveRequest.java
@@ -1,0 +1,9 @@
+package kr.codesquad.jazzmeet.inquiry.dto.request;
+
+public record InquirySaveRequest(
+	String category,
+	String nickname,
+	String password,
+	String content
+) {
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/dto/response/InquirySaveResponse.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/dto/response/InquirySaveResponse.java
@@ -1,0 +1,12 @@
+package kr.codesquad.jazzmeet.inquiry.dto.response;
+
+import java.time.LocalDateTime;
+
+public record InquirySaveResponse(
+	Long id,
+	String status,
+	String content,
+	String nickname,
+	LocalDateTime createdAt
+) {
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/entity/Answer.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/entity/Answer.java
@@ -2,6 +2,9 @@ package kr.codesquad.jazzmeet.inquiry.entity;
 
 import java.time.LocalDateTime;
 
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -32,8 +35,10 @@ public class Answer {
 	private Inquiry inquiry;
 	@Column(nullable = false)
 	private Long adminId;
+	@CreationTimestamp
 	@Column(nullable = false)
 	private LocalDateTime createdAt;
+	@UpdateTimestamp
 	@Column(nullable = false)
 	private LocalDateTime modifiedAt;
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/entity/Inquiry.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/entity/Inquiry.java
@@ -2,6 +2,8 @@ package kr.codesquad.jazzmeet.inquiry.entity;
 
 import java.time.LocalDateTime;
 
+import org.hibernate.annotations.CreationTimestamp;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -38,6 +40,7 @@ public class Inquiry {
 	@Enumerated(value = EnumType.STRING)
 	@Column(nullable = false, length = 10)
 	private InquiryStatus status;
+	@CreationTimestamp
 	@Column(nullable = false)
 	private LocalDateTime createdAt;
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/entity/Inquiry.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/entity/Inquiry.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import org.hibernate.annotations.CreationTimestamp;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -11,6 +12,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
 import kr.codesquad.jazzmeet.inquiry.util.InquiryCategory;
 import kr.codesquad.jazzmeet.inquiry.util.InquiryStatus;
 import lombok.AccessLevel;
@@ -18,11 +21,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Inquiry {
 
-	@Getter
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -43,6 +46,8 @@ public class Inquiry {
 	@CreationTimestamp
 	@Column(nullable = false)
 	private LocalDateTime createdAt;
+	@OneToOne(mappedBy = "inquiry", cascade = CascadeType.REMOVE, orphanRemoval = true)
+	private Answer answer;
 
 	@Builder
 	public Inquiry(String nickname, String password, String content, InquiryCategory category,
@@ -53,5 +58,12 @@ public class Inquiry {
 		this.category = category;
 		this.status = status;
 		this.createdAt = createdAt;
+	}
+
+	@PrePersist
+	public void PrePersist() { // DB에 default 값 넣어주는 역할
+		if (this.status == null) {
+			this.status = InquiryStatus.WAITING;
+		}
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/mapper/InquiryMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/mapper/InquiryMapper.java
@@ -46,7 +46,8 @@ public interface InquiryMapper {
 		InquiryAnswerDetail answer);
 
 	@Mapping(target = "category", source = "inquiryCategory")
-	Inquiry toInquiry(InquirySaveRequest inquirySaveRequest, InquiryCategory inquiryCategory);
+	@Mapping(target = "password", source = "encryptedPwd")
+	Inquiry toInquiry(InquirySaveRequest inquirySaveRequest, InquiryCategory inquiryCategory, String encryptedPwd);
 
 	@Mapping(target = "status", source = "status.koName")
 	InquirySaveResponse toInquirySaveResponse(Inquiry savedInquiry);

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/mapper/InquiryMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/mapper/InquiryMapper.java
@@ -6,10 +6,14 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
+import kr.codesquad.jazzmeet.inquiry.dto.request.InquirySaveRequest;
 import kr.codesquad.jazzmeet.inquiry.dto.response.InquiryAnswerDetail;
 import kr.codesquad.jazzmeet.inquiry.dto.response.InquiryDetailResponse;
+import kr.codesquad.jazzmeet.inquiry.dto.response.InquirySaveResponse;
 import kr.codesquad.jazzmeet.inquiry.dto.response.InquirySearch;
 import kr.codesquad.jazzmeet.inquiry.dto.response.InquirySearchResponse;
+import kr.codesquad.jazzmeet.inquiry.entity.Inquiry;
+import kr.codesquad.jazzmeet.inquiry.util.InquiryCategory;
 import kr.codesquad.jazzmeet.inquiry.vo.InquiryDetail;
 import kr.codesquad.jazzmeet.inquiry.vo.InquirySearchData;
 
@@ -40,4 +44,10 @@ public interface InquiryMapper {
 	@Mapping(target = "answer", source = "answer")
 	InquiryDetailResponse toInquiryDetailResponse(Long inquiryId, String inquiryContent,
 		InquiryAnswerDetail answer);
+
+	@Mapping(target = "category", source = "inquiryCategory")
+	Inquiry toInquiry(InquirySaveRequest inquirySaveRequest, InquiryCategory inquiryCategory);
+
+	@Mapping(target = "status", source = "status.koName")
+	InquirySaveResponse toInquirySaveResponse(Inquiry savedInquiry);
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/service/InquiryService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/service/InquiryService.java
@@ -33,9 +33,7 @@ public class InquiryService {
 	private static final int PAGE_SIZE = 10;
 
 	private final InquiryQueryRepository inquiryQueryRepository;
-
 	private final InquiryRepository inquiryRepository;
-
 	private final Encrypt encrypt;
 
 	public InquirySearchResponse getInquiries(String category, String word, int page) {
@@ -73,7 +71,6 @@ public class InquiryService {
 
 	@Transactional
 	public InquirySaveResponse save(InquirySaveRequest inquirySaveRequest) {
-		// TODO: 비밀번호 암호화 하기
 		String encryptedPwd = encrypt.getEncrypted(inquirySaveRequest.password());
 		InquiryCategory inquiryCategory = InquiryCategory.toInquiryCategory(inquirySaveRequest.category());
 		Inquiry inquiry = InquiryMapper.INSTANCE.toInquiry(inquirySaveRequest, inquiryCategory, encryptedPwd);

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/service/InquiryService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/service/InquiryService.java
@@ -19,7 +19,7 @@ import kr.codesquad.jazzmeet.inquiry.entity.Inquiry;
 import kr.codesquad.jazzmeet.inquiry.mapper.InquiryMapper;
 import kr.codesquad.jazzmeet.inquiry.repository.InquiryQueryRepository;
 import kr.codesquad.jazzmeet.inquiry.repository.InquiryRepository;
-import kr.codesquad.jazzmeet.inquiry.util.Encrypt;
+import kr.codesquad.jazzmeet.inquiry.util.EncryptPasswordEncoder;
 import kr.codesquad.jazzmeet.inquiry.util.InquiryCategory;
 import kr.codesquad.jazzmeet.inquiry.vo.InquiryDetail;
 import kr.codesquad.jazzmeet.inquiry.vo.InquirySearchData;
@@ -34,7 +34,7 @@ public class InquiryService {
 
 	private final InquiryQueryRepository inquiryQueryRepository;
 	private final InquiryRepository inquiryRepository;
-	private final Encrypt encrypt;
+	private final EncryptPasswordEncoder encryptPasswordEncoder;
 
 	public InquirySearchResponse getInquiries(String category, String word, int page) {
 		// request는 한글, DB 저장은 영어로 되어있기 때문에 변환 필요.
@@ -71,7 +71,7 @@ public class InquiryService {
 
 	@Transactional
 	public InquirySaveResponse save(InquirySaveRequest inquirySaveRequest) {
-		String encryptedPwd = encrypt.getEncrypted(inquirySaveRequest.password());
+		String encryptedPwd = encryptPasswordEncoder.encode(inquirySaveRequest.password());
 		InquiryCategory inquiryCategory = InquiryCategory.toInquiryCategory(inquirySaveRequest.category());
 		Inquiry inquiry = InquiryMapper.INSTANCE.toInquiry(inquirySaveRequest, inquiryCategory, encryptedPwd);
 		Inquiry savedInquiry = inquiryRepository.save(inquiry);

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/service/InquiryService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/service/InquiryService.java
@@ -5,13 +5,17 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import kr.codesquad.jazzmeet.global.error.CustomException;
 import kr.codesquad.jazzmeet.global.error.statuscode.InquiryErrorCode;
+import kr.codesquad.jazzmeet.inquiry.dto.request.InquirySaveRequest;
 import kr.codesquad.jazzmeet.inquiry.dto.response.InquiryAnswerDetail;
 import kr.codesquad.jazzmeet.inquiry.dto.response.InquiryDetailResponse;
+import kr.codesquad.jazzmeet.inquiry.dto.response.InquirySaveResponse;
 import kr.codesquad.jazzmeet.inquiry.dto.response.InquirySearch;
 import kr.codesquad.jazzmeet.inquiry.dto.response.InquirySearchResponse;
+import kr.codesquad.jazzmeet.inquiry.entity.Inquiry;
 import kr.codesquad.jazzmeet.inquiry.mapper.InquiryMapper;
 import kr.codesquad.jazzmeet.inquiry.repository.InquiryQueryRepository;
 import kr.codesquad.jazzmeet.inquiry.repository.InquiryRepository;
@@ -20,6 +24,7 @@ import kr.codesquad.jazzmeet.inquiry.vo.InquiryDetail;
 import kr.codesquad.jazzmeet.inquiry.vo.InquirySearchData;
 import lombok.RequiredArgsConstructor;
 
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class InquiryService {
@@ -61,5 +66,16 @@ public class InquiryService {
 
 		return InquiryMapper.INSTANCE.toInquiryDetailResponse(inquiry.getInquiryId(), inquiry.getInquiryContent(),
 			inquiryAnswer);
+	}
+
+	@Transactional
+	public InquirySaveResponse save(InquirySaveRequest inquirySaveRequest) {
+		// TODO: request validate 하기
+		// TODO: 비밀번호 암호화 하기
+		InquiryCategory inquiryCategory = InquiryCategory.toInquiryCategory(inquirySaveRequest.category());
+		Inquiry inquiry = InquiryMapper.INSTANCE.toInquiry(inquirySaveRequest, inquiryCategory);
+		Inquiry savedInquiry = inquiryRepository.save(inquiry);
+
+		return InquiryMapper.INSTANCE.toInquirySaveResponse(savedInquiry);
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/service/InquiryService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/service/InquiryService.java
@@ -70,7 +70,6 @@ public class InquiryService {
 
 	@Transactional
 	public InquirySaveResponse save(InquirySaveRequest inquirySaveRequest) {
-		// TODO: request validate 하기
 		// TODO: 비밀번호 암호화 하기
 		InquiryCategory inquiryCategory = InquiryCategory.toInquiryCategory(inquirySaveRequest.category());
 		Inquiry inquiry = InquiryMapper.INSTANCE.toInquiry(inquirySaveRequest, inquiryCategory);

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/service/InquiryService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/service/InquiryService.java
@@ -19,6 +19,7 @@ import kr.codesquad.jazzmeet.inquiry.entity.Inquiry;
 import kr.codesquad.jazzmeet.inquiry.mapper.InquiryMapper;
 import kr.codesquad.jazzmeet.inquiry.repository.InquiryQueryRepository;
 import kr.codesquad.jazzmeet.inquiry.repository.InquiryRepository;
+import kr.codesquad.jazzmeet.inquiry.util.Encrypt;
 import kr.codesquad.jazzmeet.inquiry.util.InquiryCategory;
 import kr.codesquad.jazzmeet.inquiry.vo.InquiryDetail;
 import kr.codesquad.jazzmeet.inquiry.vo.InquirySearchData;
@@ -34,6 +35,8 @@ public class InquiryService {
 	private final InquiryQueryRepository inquiryQueryRepository;
 
 	private final InquiryRepository inquiryRepository;
+
+	private final Encrypt encrypt;
 
 	public InquirySearchResponse getInquiries(String category, String word, int page) {
 		// request는 한글, DB 저장은 영어로 되어있기 때문에 변환 필요.
@@ -71,10 +74,12 @@ public class InquiryService {
 	@Transactional
 	public InquirySaveResponse save(InquirySaveRequest inquirySaveRequest) {
 		// TODO: 비밀번호 암호화 하기
+		String encryptedPwd = encrypt.getEncrypted(inquirySaveRequest.password());
 		InquiryCategory inquiryCategory = InquiryCategory.toInquiryCategory(inquirySaveRequest.category());
-		Inquiry inquiry = InquiryMapper.INSTANCE.toInquiry(inquirySaveRequest, inquiryCategory);
+		Inquiry inquiry = InquiryMapper.INSTANCE.toInquiry(inquirySaveRequest, inquiryCategory, encryptedPwd);
 		Inquiry savedInquiry = inquiryRepository.save(inquiry);
 
 		return InquiryMapper.INSTANCE.toInquirySaveResponse(savedInquiry);
 	}
+
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/util/Encrypt.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/util/Encrypt.java
@@ -1,0 +1,44 @@
+package kr.codesquad.jazzmeet.inquiry.util;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import kr.codesquad.jazzmeet.global.error.CustomException;
+import kr.codesquad.jazzmeet.global.error.statuscode.InquiryErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class Encrypt {
+
+	@Value("${encrypt.secret.salt}")
+	private String salt;
+
+	public String getEncrypted(String pwd) {
+		String result = null;
+		try {
+			// 1. SHA256 알고리즘 객체 생성
+			MessageDigest md = MessageDigest.getInstance("SHA-256");
+
+			// 2. pwd 와 salt 합친 문자열에 SHA256 적용
+			md.update((pwd + salt).getBytes());
+			byte[] saltedPwd = md.digest();
+
+			// 3. byte to String (10진수 문자열로 변경)
+			StringBuffer sb = new StringBuffer();
+			for (byte b : saltedPwd) {
+				sb.append(String.format("%02x", b));
+			}
+
+			result = sb.toString();
+		} catch (NoSuchAlgorithmException e) {
+			throw new CustomException(InquiryErrorCode.NO_SUCH_ALGORITHM);
+		}
+		return result;
+	}
+
+}
+

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/util/EncryptPasswordEncoder.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/util/EncryptPasswordEncoder.java
@@ -12,12 +12,12 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Component
-public class Encrypt {
+public class EncryptPasswordEncoder {
 
 	@Value("${encrypt.secret.salt}")
 	private String salt;
 
-	public String getEncrypted(String pwd) {
+	public String encode(String pwd) {
 		String result = null;
 		try {
 			// 1. SHA256 알고리즘 객체 생성

--- a/be/src/test/java/kr/codesquad/jazzmeet/fixture/InquiryFixture.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/fixture/InquiryFixture.java
@@ -2,6 +2,7 @@ package kr.codesquad.jazzmeet.fixture;
 
 import java.time.LocalDateTime;
 
+import kr.codesquad.jazzmeet.inquiry.dto.request.InquirySaveRequest;
 import kr.codesquad.jazzmeet.inquiry.entity.Answer;
 import kr.codesquad.jazzmeet.inquiry.entity.Inquiry;
 import kr.codesquad.jazzmeet.inquiry.util.InquiryCategory;
@@ -67,4 +68,13 @@ public class InquiryFixture {
 			.build();
 	}
 
+	public static InquirySaveRequest createInquiryRequest(String category, String nickname, String password,
+		String content) {
+		return InquirySaveRequest.builder()
+			.category(category)
+			.nickname(nickname)
+			.password(password)
+			.content(content)
+			.build();
+	}
 }


### PR DESCRIPTION
## What is this PR? 👓
- https://github.com/jazz-meet/jazz-meet/issues/128

## Key changes 🔑
- Entity 클래스 설정을 변경했습니다.
    - `@OneToOne()` 옵션을 추가했습니다.
    - 어플리케이션에서 DB 저장 시에 default  값을 넣어주는 설정을 추가했습니다. (테이블 default 설정 아님)
        - createdAt은 `@CreationTimestamp`
        - modifiedAt은 `@UpdateTimestamp`
        - InquiryCategory는`@Prepersist`를 사용해서 DB에 insert 문을 보낼 때, 해당 메서드에 넣은 값을 같이 insert 하게 해준다고 합니다.
        (`@ColumnDefault(value = "'")` 나 `@Column(columnDefinition = "") `으로는 원하는 결과가 나오지 않았습니다)
- 암호화 알고리즘이 담긴 클래스와 메서드를 만들었습니다 (EncryptPasswordEncoder.class)
    - 비밀번호와 yml에 설정해 둔 salt(secret key)를 합치고, SHA256 알고리즘 방식을 이용해 암호화를 진행했습니다.

## To reviewers 👋
- 암호화를 위한 application-encrypt.yml을 추가했고, 서브모듈에 반영했습니다.
- Mapstruct에 정의된 메서드의 인자에 배열이 들어올 때 간단히 해결하는 방법을 발견했습니다! [블로그](https://itsowavy.oopy.io/spring/mapstruct-mapping-2)
- 테스트 코드 금방 짤 줄 알았는데 암호화 테스트 하는데 시간이 좀 걸렸습니다.. 
    - 테스트 메서드 내부에서 new EncryptPasswordEncoder 로 객체 생성해서 암호화를 진행하니까, 생성한 객체로 암호화 한 비밀번호와, 서비스 클래스 내부에서 save() 될 때 암호화 된 비밀번호가 일치하지 않는 일이 발생했는데, 암호화 하는 클래스도 test 하는 클래스 내의 필드로 설정해야 (`@Autowired` 걸어줘야) 같은 값으로 암호화가 되는 것을 발견했습니다.
