### PR TITLE
공연 상세 조회 API 구현

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ShowErrorCode.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ShowErrorCode.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ShowErrorCode implements StatusCode {
 
-	NOT_VALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "날짜 포맷이 잘못되었습니다. 'yyyyMMdd' 형식으로 입력해주세요");
+	NOT_VALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "날짜 포맷이 잘못되었습니다. 'yyyyMMdd' 형식으로 입력해주세요"),
+	NOT_FOUND_SHOW(HttpStatus.NOT_FOUND, "해당하는 공연이 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/controller/ShowController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/controller/ShowController.java
@@ -10,10 +10,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.constraints.Min;
-import kr.codesquad.jazzmeet.show.dto.ShowResponse;
 import kr.codesquad.jazzmeet.show.dto.response.ExistShowCalendarResponse;
 import kr.codesquad.jazzmeet.show.dto.response.ShowByDateAndVenueResponse;
 import kr.codesquad.jazzmeet.show.dto.response.ShowByDateResponse;
+import kr.codesquad.jazzmeet.show.dto.response.ShowDetailResponse;
+import kr.codesquad.jazzmeet.show.dto.response.ShowResponse;
 import kr.codesquad.jazzmeet.show.dto.response.UpcomingShowResponse;
 import kr.codesquad.jazzmeet.show.service.ShowService;
 import lombok.RequiredArgsConstructor;
@@ -82,5 +83,15 @@ public class ShowController {
 		ShowResponse showResponse = showService.getShows(word, page);
 
 		return ResponseEntity.ok(showResponse);
+	}
+
+	/**
+	 * 공연 상세 조회 API
+	 */
+	@GetMapping("/api/shows/{showId}")
+	public ResponseEntity<ShowDetailResponse> getShowDetail(@PathVariable Long showId) {
+		ShowDetailResponse showDetailResponse = showService.getShowDetail(showId);
+
+		return ResponseEntity.ok(showDetailResponse);
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/dto/response/ShowDetailResponse.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/dto/response/ShowDetailResponse.java
@@ -1,0 +1,18 @@
+package kr.codesquad.jazzmeet.show.dto.response;
+
+import java.time.LocalDateTime;
+
+import kr.codesquad.jazzmeet.show.vo.ShowPoster;
+import lombok.Builder;
+
+@Builder
+public record ShowDetailResponse(
+	Long id,
+	String showName,
+	String venueName,
+	String description,
+	ShowPoster poster,
+	LocalDateTime startTime,
+	LocalDateTime endTime
+) {
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/dto/response/ShowResponse.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/dto/response/ShowResponse.java
@@ -1,4 +1,4 @@
-package kr.codesquad.jazzmeet.show.dto;
+package kr.codesquad.jazzmeet.show.dto.response;
 
 import java.util.List;
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
@@ -5,8 +5,9 @@ import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 import org.springframework.data.domain.Page;
 
-import kr.codesquad.jazzmeet.show.dto.ShowResponse;
 import kr.codesquad.jazzmeet.show.dto.response.ShowByDateAndVenueResponse;
+import kr.codesquad.jazzmeet.show.dto.response.ShowDetailResponse;
+import kr.codesquad.jazzmeet.show.dto.response.ShowResponse;
 import kr.codesquad.jazzmeet.show.dto.response.UpcomingShowResponse;
 import kr.codesquad.jazzmeet.show.entity.Show;
 import kr.codesquad.jazzmeet.show.vo.ShowSummaryWithVenue;
@@ -29,4 +30,8 @@ public interface ShowMapper {
 	@Mapping(target = "currentPage", expression = "java(page.getNumber() + 1)")
 	@Mapping(target = "shows", source = "content")
 	ShowResponse toShowResponse(Page<ShowSummaryWithVenue> page);
+
+	@Mapping(target = "venueName", source = "venue.name")
+	@Mapping(target = "showName", source = "teamName")
+	ShowDetailResponse toShowDetailResponse(Show show);
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/ShowRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/ShowRepository.java
@@ -3,6 +3,7 @@ package kr.codesquad.jazzmeet.show.repository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -19,4 +20,7 @@ public interface ShowRepository extends JpaRepository<Show, Long> {
 
 	@Query("select s from Show s where s.venue.id = :venueId and FUNCTION('DATE', s.startTime) = :date")
 	List<Show> findByVenueIdAndDate(@Param("venueId") Long venueId, @Param("date") LocalDate date);
+
+	@Query("select s from Show s join fetch s.venue join fetch s.poster where s.id = :showId")
+	Optional<Show> findEntireShowById(@Param("showId") Long showId);
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowService.java
@@ -16,10 +16,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kr.codesquad.jazzmeet.global.error.CustomException;
 import kr.codesquad.jazzmeet.global.error.statuscode.ShowErrorCode;
-import kr.codesquad.jazzmeet.show.dto.ShowResponse;
 import kr.codesquad.jazzmeet.show.dto.response.ExistShowCalendarResponse;
 import kr.codesquad.jazzmeet.show.dto.response.ShowByDateAndVenueResponse;
 import kr.codesquad.jazzmeet.show.dto.response.ShowByDateResponse;
+import kr.codesquad.jazzmeet.show.dto.response.ShowDetailResponse;
+import kr.codesquad.jazzmeet.show.dto.response.ShowResponse;
 import kr.codesquad.jazzmeet.show.dto.response.UpcomingShowResponse;
 import kr.codesquad.jazzmeet.show.entity.Show;
 import kr.codesquad.jazzmeet.show.mapper.ShowMapper;
@@ -112,5 +113,16 @@ public class ShowService {
 		Page<ShowSummaryWithVenue> shows = showQueryRepository.getShows(word, pageRequest);
 
 		return ShowMapper.INSTANCE.toShowResponse(shows);
+	}
+
+	public ShowDetailResponse getShowDetail(Long showId) {
+		Show show = getShowById(showId);
+
+		return ShowMapper.INSTANCE.toShowDetailResponse(show);
+	}
+
+	private Show getShowById(Long showId) {
+		return showRepository.findEntireShowById(showId)
+			.orElseThrow(() -> new CustomException(ShowErrorCode.NOT_FOUND_SHOW));
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/vo/ShowPoster.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/vo/ShowPoster.java
@@ -1,0 +1,14 @@
+package kr.codesquad.jazzmeet.show.vo;
+
+import lombok.Getter;
+
+@Getter
+public class ShowPoster {
+	private Long id;
+	private String url;
+
+	public ShowPoster(Long id, String url) {
+		this.id = id;
+		this.url = url;
+	}
+}

--- a/be/src/test/java/kr/codesquad/jazzmeet/fixture/ShowFixture.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/fixture/ShowFixture.java
@@ -35,4 +35,14 @@ public class ShowFixture {
 			.venue(venue)
 			.build();
 	}
+
+	public static Show createShow(String teamName, LocalDateTime time, Venue venue, Image image) {
+		return Show.builder()
+			.teamName(teamName)
+			.poster(image)
+			.startTime(time)
+			.endTime(time)
+			.venue(venue)
+			.build();
+	}
 }

--- a/be/src/test/java/kr/codesquad/jazzmeet/show/controller/ShowControllerTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/show/controller/ShowControllerTest.java
@@ -1,6 +1,7 @@
 package kr.codesquad.jazzmeet.show.controller;
 
 import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -16,10 +17,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import kr.codesquad.jazzmeet.show.dto.ShowResponse;
 import kr.codesquad.jazzmeet.show.dto.response.ExistShowCalendarResponse;
 import kr.codesquad.jazzmeet.show.dto.response.ShowByDateResponse;
+import kr.codesquad.jazzmeet.show.dto.response.ShowDetailResponse;
+import kr.codesquad.jazzmeet.show.dto.response.ShowResponse;
 import kr.codesquad.jazzmeet.show.service.ShowService;
+import kr.codesquad.jazzmeet.show.vo.ShowPoster;
 
 @WebMvcTest(controllers = ShowController.class)
 class ShowControllerTest {
@@ -107,5 +110,26 @@ class ShowControllerTest {
 			.andExpect(jsonPath("$.currentPage").value(1))
 			.andExpect(jsonPath("$.maxPage").value(3))
 			.andExpect(jsonPath("$.totalCount").value(30));
+	}
+
+	@DisplayName("관리자가 공연의 id로 공연을 상세 조회한다.")
+	@Test
+	void getShowDetail() throws Exception {
+		//given
+		Long showId = 1L;
+		when(showService.getShowDetail(any())).thenReturn(
+			ShowDetailResponse.builder().id(showId).poster(new ShowPoster(1L, "url")).showName("퀄텟").build());
+
+		//when //then
+		mockMvc.perform(
+				get("/api/shows/{showId}", showId)
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id").value(1L))
+			.andExpect(jsonPath("$.poster.id").value(1L))
+			.andExpect(jsonPath("$.poster.url").value("url"))
+			.andExpect(jsonPath("$.showName").value("퀄텟"));
 	}
 }

--- a/be/src/test/java/kr/codesquad/jazzmeet/show/repository/ShowRepositoryTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/show/repository/ShowRepositoryTest.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,8 +16,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 import kr.codesquad.jazzmeet.IntegrationTestSupport;
+import kr.codesquad.jazzmeet.fixture.ImageFixture;
 import kr.codesquad.jazzmeet.fixture.ShowFixture;
 import kr.codesquad.jazzmeet.fixture.VenueFixture;
+import kr.codesquad.jazzmeet.image.entity.Image;
 import kr.codesquad.jazzmeet.show.entity.Show;
 import kr.codesquad.jazzmeet.show.vo.ShowSummaryWithVenue;
 import kr.codesquad.jazzmeet.show.vo.ShowWithVenue;
@@ -199,5 +202,36 @@ class ShowRepositoryTest extends IntegrationTestSupport {
 		assertThat(response.getContent()).hasSize(2)
 			.extracting("teamName")
 			.contains("Entry55 퀄텟1", "Entry55 퀄텟2");
+	}
+
+	@DisplayName("공연의 id로 공연을 조회한다.")
+	@Test
+	void getShowById() throws Exception {
+		//given
+		LocalDateTime time = LocalDateTime.of(2023, 11, 1, 20, 00);
+		Image image = ImageFixture.createImage("url");
+		Venue venue = VenueFixture.createVenue("부기우기", "경기 고양시 덕양구");
+		Show show = ShowFixture.createShow("Entry55 퀄텟1", time, venue, image);
+		showRepository.save(show);
+
+		Long id = show.getId();
+
+		//when
+		Show findShow = showRepository.findEntireShowById(id).get();
+
+		//then
+		Assertions.assertAll(
+			() -> assertThat(findShow)
+				.extracting("teamName", "startTime", "endTime")
+				.contains("Entry55 퀄텟1", time, time),
+
+			() -> assertThat(findShow.getPoster())
+				.extracting("id", "url")
+				.contains(image.getId(), "url"),
+
+			() -> assertThat(findShow.getVenue())
+				.extracting("name")
+				.isEqualTo("부기우기")
+		);
 	}
 }


### PR DESCRIPTION
## What is this PR? 👓
공연장 상세 조회 API를 구현했습니다.

## Key changes 🔑
기존에 만들었던 ShowResponse가 dto 하위에 위치하고 있어서 dto.reponse 하위로 이동하였습니다.

## To reviewers 👋
`@AllArgsContstructor` 사용하라는 글을 어디서 봤는데 블로그에만 적혀있고 확신을 가질 수 있는 출처를 아직 못 찾았습니다. 일단 생성자는 직접 만들어서 PR 올립니다. 더 찾아보고 오겠습니다.