### PR TITLE
공연 페이지 캘린더 기능

### DIFF
--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/Calendar.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/Calendar.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import { getFirstDay, getLastDate } from '~/utils/dateUtils';
 
 type Props = {
   calendarDate: Date;
@@ -27,7 +28,7 @@ export const Calendar: React.FC<Props> = ({
   const selectedDay = selectedDate.getDate();
 
   const firstDay = getFirstDay(currentYear, currentMonth);
-  const lastDay = getLastDay(calendarDate.getFullYear(), currentMonth);
+  const lastDay = getLastDate(calendarDate.getFullYear(), currentMonth);
 
   const CalendarHeaderTitle = `${calendarDate.toLocaleString('en-US', {
     month: 'long',
@@ -78,18 +79,6 @@ export const Calendar: React.FC<Props> = ({
       </StyledDaysGrid>
     </StyledCalendar>
   );
-};
-
-const getFirstDay = (year: number, month: number) => {
-  const firstDay = new Date(year, month - 1, 1);
-
-  return firstDay.getDay();
-};
-
-const getLastDay = (year: number, month: number) => {
-  const lastDay = new Date(year, month, 0); // 0일은 지난 달의 마지막 날을 의미합니다.
-
-  return lastDay.getDate();
 };
 
 const StyledCalendar = styled.div`

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/Calendar.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/Calendar.tsx
@@ -28,7 +28,7 @@ export const Calendar: React.FC<Props> = ({
   const selectedDay = selectedDate.getDate();
 
   const firstDay = getFirstDay(currentYear, currentMonth);
-  const lastDay = getLastDate(calendarDate.getFullYear(), currentMonth);
+  const lastDate = getLastDate(calendarDate.getFullYear(), currentMonth);
 
   const CalendarHeaderTitle = `${calendarDate.toLocaleString('en-US', {
     month: 'long',

--- a/fe/user/src/pages/ShowPage/CalendarDate/DateController/DateGroup.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/DateController/DateGroup.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { equalDates, getKoreanWeekdayName, isToday } from '~/utils/dateUtils';
+import { equalDates, getKoreanWeekdayName } from '~/utils/dateUtils';
 
 type Props = {
   dates: Date[];
@@ -7,6 +7,8 @@ type Props = {
 };
 
 export const DateGroup: React.FC<Props> = ({ dates, selectedDate }) => {
+  const today = new Date();
+
   return (
     <StyledDateGroup>
       {dates.map((date: Date) => {
@@ -18,7 +20,7 @@ export const DateGroup: React.FC<Props> = ({ dates, selectedDate }) => {
             key={dateNumber}
             $active={equalDates(date, selectedDate)}
           >
-            <StyledDay>{isToday(date) ? '오늘' : day}</StyledDay>
+            <StyledDay>{equalDates(date, today) ? '오늘' : day}</StyledDay>
             <StyledDate>{dateNumber}</StyledDate>
           </StyledDateInfo>
         );

--- a/fe/user/src/pages/ShowPage/CalendarDate/DateController/DateGroup.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/DateController/DateGroup.tsx
@@ -1,23 +1,28 @@
 import styled from '@emotion/styled';
-import { DateData } from '.';
+import { equalDates, getKoreanWeekdayName, isToday } from '~/utils/dateUtils';
 
 type Props = {
-  dates: DateData[];
+  dates: Date[];
   selectedDate: Date;
 };
 
 export const DateGroup: React.FC<Props> = ({ dates, selectedDate }) => {
-  const today = new Date().getDate();
-  const selectedDateInMonth = selectedDate.getDate();
-
   return (
     <StyledDateGroup>
-      {dates.map(({ day, date }) => (
-        <StyledDateInfo key={date} $active={selectedDateInMonth === date}>
-          <StyledDay>{date === today ? '오늘' : day}</StyledDay>
-          <StyledDate>{date}</StyledDate>
-        </StyledDateInfo>
-      ))}
+      {dates.map((date: Date) => {
+        const day = getKoreanWeekdayName(date.getDay());
+        const dateNumber = date.getDate();
+
+        return (
+          <StyledDateInfo
+            key={dateNumber}
+            $active={equalDates(date, selectedDate)}
+          >
+            <StyledDay>{isToday(date) ? '오늘' : day}</StyledDay>
+            <StyledDate>{dateNumber}</StyledDate>
+          </StyledDateInfo>
+        );
+      })}
     </StyledDateGroup>
   );
 };

--- a/fe/user/src/pages/ShowPage/CalendarDate/DateController/DateGroup.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/DateController/DateGroup.tsx
@@ -3,14 +3,18 @@ import { DateData } from '.';
 
 type Props = {
   dates: DateData[];
+  selectedDate: Date;
 };
 
-export const DateGroup: React.FC<Props> = ({ dates }) => {
+export const DateGroup: React.FC<Props> = ({ dates, selectedDate }) => {
+  const today = new Date().getDate();
+  const selectedDateInMonth = selectedDate.getDate();
+
   return (
     <StyledDateGroup>
       {dates.map(({ day, date }) => (
-        <StyledDateInfo key={date}>
-          <StyledDay>{day}</StyledDay>
+        <StyledDateInfo key={date} $active={selectedDateInMonth === date}>
+          <StyledDay>{date === today ? '오늘' : day}</StyledDay>
           <StyledDate>{date}</StyledDate>
         </StyledDateInfo>
       ))}
@@ -24,11 +28,24 @@ const StyledDateGroup = styled.div`
   justify-content: space-around;
 `;
 
-const StyledDateInfo = styled.div`
+const StyledDateInfo = styled.div<{ $active: boolean }>`
   display: flex;
   flex-direction: column;
   align-items: center;
   min-width: 24px;
+
+  &:hover {
+    cursor: pointer;
+    opacity: 0.7;
+  }
+
+  &:active {
+    opacity: 0.5;
+  }
+
+  > p {
+    ${({ $active }) => $active && `color: #FF5019`}
+  }
 `;
 
 const StyledDay = styled.p`

--- a/fe/user/src/pages/ShowPage/CalendarDate/DateController/DateGroup.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/DateController/DateGroup.tsx
@@ -4,9 +4,14 @@ import { equalDates, getKoreanWeekdayName } from '~/utils/dateUtils';
 type Props = {
   dates: Date[];
   selectedDate: Date;
+  selectDate: (date: Date) => void;
 };
 
-export const DateGroup: React.FC<Props> = ({ dates, selectedDate }) => {
+export const DateGroup: React.FC<Props> = ({
+  dates,
+  selectedDate,
+  selectDate,
+}) => {
   const today = new Date();
 
   return (
@@ -19,6 +24,7 @@ export const DateGroup: React.FC<Props> = ({ dates, selectedDate }) => {
           <StyledDateInfo
             key={dateNumber}
             $active={equalDates(date, selectedDate)}
+            onClick={() => selectDate(date)}
           >
             <StyledDay>{equalDates(date, today) ? '오늘' : day}</StyledDay>
             <StyledDate>{dateNumber}</StyledDate>

--- a/fe/user/src/pages/ShowPage/CalendarDate/DateController/DateGroup.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/DateController/DateGroup.tsx
@@ -1,61 +1,11 @@
 import styled from '@emotion/styled';
+import { DateData } from '.';
 
-export const DateGroup: React.FC = () => {
-  const dates = [
-    {
-      day: '수',
-      date: 1,
-    },
-    {
-      day: '목',
-      date: 2,
-    },
-    {
-      day: '금',
-      date: 3,
-    },
-    {
-      day: '토',
-      date: 4,
-    },
-    {
-      day: '일',
-      date: 5,
-    },
-    {
-      day: '월',
-      date: 6,
-    },
-    {
-      day: '화',
-      date: 7,
-    },
-    {
-      day: '수',
-      date: 8,
-    },
-    {
-      day: '목',
-      date: 9,
-    },
-    {
-      day: '금',
-      date: 10,
-    },
-    {
-      day: '토',
-      date: 11,
-    },
-    {
-      day: '일',
-      date: 12,
-    },
-    {
-      day: '월',
-      date: 13,
-    },
-  ];
+type Props = {
+  dates: DateData[];
+};
 
+export const DateGroup: React.FC<Props> = ({ dates }) => {
   return (
     <StyledDateGroup>
       {dates.map(({ day, date }) => (

--- a/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
@@ -1,9 +1,44 @@
 import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
 import CaretLeft from '~/assets/icons/CaretLeft.svg?react';
 import CaretRight from '~/assets/icons/CaretRight.svg?react';
+import { getFirstDay, getLastDate, getMonthDates } from '~/utils/dateUtils';
 import { DateGroup } from './DateGroup';
 
-export const DateController: React.FC = () => {
+export type DateData = {
+  date: number;
+  day: string;
+};
+
+type Props = {
+  calendarDate: Date;
+  selectedDate: Date;
+  selectDate: (date: Date) => void;
+};
+
+export const DateController: React.FC<Props> = ({
+  calendarDate,
+  selectedDate,
+  selectDate,
+}) => {
+  const [datesInMonth, setDatesInMonth] = useState<DateData[]>([]);
+  const [page, setPage] = useState();
+
+  const todayIndex = selectedDate.getDate() - 1;
+  const currentDateGroup = getCurrentDateGroup(datesInMonth, todayIndex, page);
+
+  useEffect(() => {
+    const currentYear = calendarDate.getFullYear();
+    const currentMonth = calendarDate.getMonth() + 1;
+
+    const firstDay = getFirstDay(currentYear, currentMonth);
+    const lastDate = getLastDate(currentYear, currentMonth);
+
+    const dates = getMonthDates(firstDay, lastDate);
+
+    setDatesInMonth(dates);
+  }, [calendarDate]);
+
   const goToPreviousGroup = () => {};
   const goToNextGroup = () => {};
 
@@ -12,12 +47,32 @@ export const DateController: React.FC = () => {
       <StyledArrowButton>
         <CaretLeft onClick={goToPreviousGroup} />
       </StyledArrowButton>
-      <DateGroup />
+      <DateGroup dates={currentDateGroup} />
       <StyledArrowButton>
         <CaretRight onClick={goToNextGroup} />
       </StyledArrowButton>
     </StyledDateContainer>
   );
+};
+
+const getCurrentDateGroup = (
+  datesInMonth: DateData[],
+  todayIndex?: number,
+  page?: number,
+) => {
+  if (typeof todayIndex !== 'undefined' && todayIndex !== 0) {
+    return todayIndex < 7
+      ? datesInMonth.slice(0, 13)
+      : datesInMonth.length - todayIndex < 7
+      ? datesInMonth.slice(datesInMonth.length - 13, datesInMonth.length)
+      : datesInMonth.slice(todayIndex - 6, todayIndex + 7);
+  }
+
+  if (typeof page !== 'undefined' && page >= 0 && page < 3) {
+    return datesInMonth.slice(page * 13, (page + 1) * 13);
+  }
+
+  return datesInMonth.slice(0, 13);
 };
 
 const StyledDateContainer = styled.div`

--- a/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
 import CaretLeft from '~/assets/icons/CaretLeft.svg?react';
 import CaretRight from '~/assets/icons/CaretRight.svg?react';
-import { getFirstDay, getLastDate, getMonthDates } from '~/utils/dateUtils';
+import { getMonthDates } from '~/utils/dateUtils';
 import { DateGroup } from './DateGroup';
 
 export type DateData = {
@@ -21,10 +21,8 @@ export const DateController: React.FC<Props> = ({
   selectedDate,
   selectDate,
 }) => {
-  const [datesInMonth, setDatesInMonth] = useState<DateData[]>([]);
-  const [centerDateIndex, setCenterDateIndex] = useState(
-    selectedDate.getDate() - 1,
-  );
+  const [datesInMonth, setDatesInMonth] = useState<Date[]>([]);
+  const [centerDateIndex, setCenterDateIndex] = useState(0);
 
   const currentDateGroup = getCurrentDateGroup(datesInMonth, centerDateIndex);
 
@@ -34,16 +32,9 @@ export const DateController: React.FC<Props> = ({
     setCenterDateIndex((p) => getCenterDateIndex(p + 9));
 
   useEffect(() => {
-    const currentYear = calendarDate.getFullYear();
-    const currentMonth = calendarDate.getMonth() + 1;
-
-    const firstDay = getFirstDay(currentYear, currentMonth);
-    const lastDate = getLastDate(currentYear, currentMonth);
-
-    const dates = getMonthDates(firstDay, lastDate);
-
-    setDatesInMonth(dates);
-  }, [calendarDate]);
+    setDatesInMonth(getMonthDates(calendarDate));
+    setCenterDateIndex(selectedDate.getDate() - 1);
+  }, [calendarDate, selectedDate]);
 
   return (
     <StyledDateContainer>
@@ -58,7 +49,7 @@ export const DateController: React.FC<Props> = ({
   );
 };
 
-const getCurrentDateGroup = (datesInMonth: DateData[], dateIndex: number) => {
+const getCurrentDateGroup = (datesInMonth: Date[], dateIndex: number) => {
   if (dateIndex < 7) {
     return datesInMonth.slice(0, 13);
   }

--- a/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
@@ -5,11 +5,6 @@ import CaretRight from '~/assets/icons/CaretRight.svg?react';
 import { getMonthDates } from '~/utils/dateUtils';
 import { DateGroup } from './DateGroup';
 
-export type DateData = {
-  date: number;
-  day: string;
-};
-
 type Props = {
   selectedDate: Date;
   selectDate: (date: Date) => void;

--- a/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
@@ -41,7 +41,11 @@ export const DateController: React.FC<Props> = ({
       <StyledArrowButton>
         <CaretLeft onClick={goToPreviousGroup} />
       </StyledArrowButton>
-      <DateGroup dates={currentDateGroup} selectedDate={selectedDate} />
+      <DateGroup
+        dates={currentDateGroup}
+        selectedDate={selectedDate}
+        selectDate={selectDate}
+      />
       <StyledArrowButton>
         <CaretRight onClick={goToNextGroup} />
       </StyledArrowButton>

--- a/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
@@ -11,13 +11,11 @@ export type DateData = {
 };
 
 type Props = {
-  calendarDate: Date;
   selectedDate: Date;
   selectDate: (date: Date) => void;
 };
 
 export const DateController: React.FC<Props> = ({
-  calendarDate,
   selectedDate,
   selectDate,
 }) => {
@@ -32,9 +30,9 @@ export const DateController: React.FC<Props> = ({
     setCenterDateIndex((p) => getCenterDateIndex(p + 9));
 
   useEffect(() => {
-    setDatesInMonth(getMonthDates(calendarDate));
+    setDatesInMonth(getMonthDates(selectedDate));
     setCenterDateIndex(selectedDate.getDate() - 1);
-  }, [calendarDate, selectedDate]);
+  }, [selectedDate]);
 
   return (
     <StyledDateContainer>

--- a/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
@@ -22,13 +22,16 @@ export const DateController: React.FC<Props> = ({
   selectDate,
 }) => {
   const [datesInMonth, setDatesInMonth] = useState<DateData[]>([]);
-  const [page, setPage] = useState();
-
-  const currentDateGroup = getCurrentDateGroup(
-    datesInMonth,
+  const [centerDateIndex, setCenterDateIndex] = useState(
     selectedDate.getDate() - 1,
-    page,
   );
+
+  const currentDateGroup = getCurrentDateGroup(datesInMonth, centerDateIndex);
+
+  const goToPreviousGroup = () =>
+    setCenterDateIndex((p) => getCenterDateIndex(p - 9));
+  const goToNextGroup = () =>
+    setCenterDateIndex((p) => getCenterDateIndex(p + 9));
 
   useEffect(() => {
     const currentYear = calendarDate.getFullYear();
@@ -41,9 +44,6 @@ export const DateController: React.FC<Props> = ({
 
     setDatesInMonth(dates);
   }, [calendarDate]);
-
-  const goToPreviousGroup = () => {};
-  const goToNextGroup = () => {};
 
   return (
     <StyledDateContainer>
@@ -58,24 +58,28 @@ export const DateController: React.FC<Props> = ({
   );
 };
 
-const getCurrentDateGroup = (
-  datesInMonth: DateData[],
-  dateIndex?: number,
-  page?: number,
-) => {
-  if (typeof dateIndex !== 'undefined' && dateIndex !== 0) {
-    return dateIndex < 7
-      ? datesInMonth.slice(0, 13)
-      : datesInMonth.length - dateIndex < 7
-      ? datesInMonth.slice(datesInMonth.length - 13, datesInMonth.length)
-      : datesInMonth.slice(dateIndex - 6, dateIndex + 7);
+const getCurrentDateGroup = (datesInMonth: DateData[], dateIndex: number) => {
+  if (dateIndex < 7) {
+    return datesInMonth.slice(0, 13);
   }
 
-  if (typeof page !== 'undefined' && page >= 0 && page < 3) {
-    return datesInMonth.slice(page * 13, (page + 1) * 13);
+  if (datesInMonth.length - dateIndex < 7) {
+    return datesInMonth.slice(datesInMonth.length - 13, datesInMonth.length);
   }
 
-  return datesInMonth.slice(0, 13);
+  return datesInMonth.slice(dateIndex - 6, dateIndex + 7);
+};
+
+const getCenterDateIndex = (index: number) => {
+  if (index < 7) {
+    return 6;
+  }
+
+  if (index < 16) {
+    return 15;
+  }
+
+  return 24;
 };
 
 const StyledDateContainer = styled.div`

--- a/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
@@ -24,8 +24,11 @@ export const DateController: React.FC<Props> = ({
   const [datesInMonth, setDatesInMonth] = useState<DateData[]>([]);
   const [page, setPage] = useState();
 
-  const todayIndex = selectedDate.getDate() - 1;
-  const currentDateGroup = getCurrentDateGroup(datesInMonth, todayIndex, page);
+  const currentDateGroup = getCurrentDateGroup(
+    datesInMonth,
+    selectedDate.getDate() - 1,
+    page,
+  );
 
   useEffect(() => {
     const currentYear = calendarDate.getFullYear();
@@ -47,7 +50,7 @@ export const DateController: React.FC<Props> = ({
       <StyledArrowButton>
         <CaretLeft onClick={goToPreviousGroup} />
       </StyledArrowButton>
-      <DateGroup dates={currentDateGroup} />
+      <DateGroup dates={currentDateGroup} selectedDate={selectedDate} />
       <StyledArrowButton>
         <CaretRight onClick={goToNextGroup} />
       </StyledArrowButton>
@@ -57,15 +60,15 @@ export const DateController: React.FC<Props> = ({
 
 const getCurrentDateGroup = (
   datesInMonth: DateData[],
-  todayIndex?: number,
+  dateIndex?: number,
   page?: number,
 ) => {
-  if (typeof todayIndex !== 'undefined' && todayIndex !== 0) {
-    return todayIndex < 7
+  if (typeof dateIndex !== 'undefined' && dateIndex !== 0) {
+    return dateIndex < 7
       ? datesInMonth.slice(0, 13)
-      : datesInMonth.length - todayIndex < 7
+      : datesInMonth.length - dateIndex < 7
       ? datesInMonth.slice(datesInMonth.length - 13, datesInMonth.length)
-      : datesInMonth.slice(todayIndex - 6, todayIndex + 7);
+      : datesInMonth.slice(dateIndex - 6, dateIndex + 7);
   }
 
   if (typeof page !== 'undefined' && page >= 0 && page < 3) {

--- a/fe/user/src/pages/ShowPage/CalendarDate/Header/MonthController.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/Header/MonthController.tsx
@@ -4,25 +4,42 @@ import CaretRight from '~/assets/icons/CaretRight.svg?react';
 
 export type MonthControllerProps = {
   calendarDate: Date;
+  selectedDate: Date;
   goToPreviousMonth: () => void;
   goToNextMonth: () => void;
+  selectDate: (date: Date) => void;
 };
 
 export const MonthController: React.FC<MonthControllerProps> = ({
   calendarDate,
+  selectedDate,
   goToPreviousMonth,
   goToNextMonth,
+  selectDate,
 }) => {
   const currentYear = calendarDate.getFullYear();
   const currentMonth = calendarDate.getMonth() + 1;
 
+  const selectedYear = selectedDate.getFullYear();
+  const selectedMonth = selectedDate.getMonth() + 1;
+
   const monthText = `${currentYear}.${currentMonth}`;
+
+  const onPreviousMonthClick = () => {
+    goToPreviousMonth();
+    selectDate(new Date(selectedYear, selectedMonth - 1, 0));
+  };
+
+  const onNextMonthClick = () => {
+    goToNextMonth();
+    selectDate(new Date(selectedYear, selectedMonth, 1));
+  };
 
   return (
     <StyledMonthController>
-      <CaretLeft onClick={goToPreviousMonth} />
+      <CaretLeft onClick={onPreviousMonthClick} />
       <MonthText>{monthText}</MonthText>
-      <CaretRight onClick={goToNextMonth} />
+      <CaretRight onClick={onNextMonthClick} />
     </StyledMonthController>
   );
 };

--- a/fe/user/src/pages/ShowPage/CalendarDate/Header/MonthController.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/Header/MonthController.tsx
@@ -16,13 +16,11 @@ export const MonthController: React.FC<MonthControllerProps> = ({
 
   const monthText = `${selectedYear}.${selectedMonth}`;
 
-  const onPreviousMonthClick = () => {
+  const onPreviousMonthClick = () =>
     selectDate(new Date(selectedYear, selectedMonth - 1, 0));
-  };
 
-  const onNextMonthClick = () => {
+  const onNextMonthClick = () =>
     selectDate(new Date(selectedYear, selectedMonth, 1));
-  };
 
   return (
     <StyledMonthController>

--- a/fe/user/src/pages/ShowPage/CalendarDate/Header/MonthController.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/Header/MonthController.tsx
@@ -3,35 +3,24 @@ import CaretLeft from '~/assets/icons/CaretLeft.svg?react';
 import CaretRight from '~/assets/icons/CaretRight.svg?react';
 
 export type MonthControllerProps = {
-  calendarDate: Date;
   selectedDate: Date;
-  goToPreviousMonth: () => void;
-  goToNextMonth: () => void;
   selectDate: (date: Date) => void;
 };
 
 export const MonthController: React.FC<MonthControllerProps> = ({
-  calendarDate,
   selectedDate,
-  goToPreviousMonth,
-  goToNextMonth,
   selectDate,
 }) => {
-  const currentYear = calendarDate.getFullYear();
-  const currentMonth = calendarDate.getMonth() + 1;
-
   const selectedYear = selectedDate.getFullYear();
   const selectedMonth = selectedDate.getMonth() + 1;
 
-  const monthText = `${currentYear}.${currentMonth}`;
+  const monthText = `${selectedYear}.${selectedMonth}`;
 
   const onPreviousMonthClick = () => {
-    goToPreviousMonth();
     selectDate(new Date(selectedYear, selectedMonth - 1, 0));
   };
 
   const onNextMonthClick = () => {
-    goToNextMonth();
     selectDate(new Date(selectedYear, selectedMonth, 1));
   };
 

--- a/fe/user/src/pages/ShowPage/CalendarDate/Header/MonthController.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/Header/MonthController.tsx
@@ -2,14 +2,26 @@ import styled from '@emotion/styled';
 import CaretLeft from '~/assets/icons/CaretLeft.svg?react';
 import CaretRight from '~/assets/icons/CaretRight.svg?react';
 
-export const MonthController: React.FC = () => {
-  const goToPreviousMonth = () => {};
-  const goToNextMonth = () => {};
+export type MonthControllerProps = {
+  calendarDate: Date;
+  goToPreviousMonth: () => void;
+  goToNextMonth: () => void;
+};
+
+export const MonthController: React.FC<MonthControllerProps> = ({
+  calendarDate,
+  goToPreviousMonth,
+  goToNextMonth,
+}) => {
+  const currentYear = calendarDate.getFullYear();
+  const currentMonth = calendarDate.getMonth() + 1;
+
+  const monthText = `${currentYear}.${currentMonth}`;
 
   return (
     <StyledMonthController>
       <CaretLeft onClick={goToPreviousMonth} />
-      <MonthText>2023.11</MonthText>
+      <MonthText>{monthText}</MonthText>
       <CaretRight onClick={goToNextMonth} />
     </StyledMonthController>
   );

--- a/fe/user/src/pages/ShowPage/CalendarDate/Header/index.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/Header/index.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
-import { MonthController } from './MonthController';
+import { MonthController, MonthControllerProps } from './MonthController';
 
-export const Header: React.FC = () => {
+export const Header: React.FC<MonthControllerProps> = ({ ...props }) => {
   return (
     <StyledHeader>
-      <MonthController />
+      <MonthController {...props} />
       {/* <DatePicker /> */}
     </StyledHeader>
   );

--- a/fe/user/src/pages/ShowPage/CalendarDate/index.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/index.tsx
@@ -4,28 +4,12 @@ import { DateController } from './DateController';
 import { Header } from './Header';
 
 export const CalendarDate: React.FC = () => {
-  const {
-    calendarDate,
-    selectedDate,
-    goToPreviousMonth,
-    goToNextMonth,
-    selectDate,
-  } = useCalendar();
+  const { selectedDate, selectDate } = useCalendar();
 
   return (
     <StyledCalendarDate>
-      <Header
-        calendarDate={calendarDate}
-        selectedDate={selectedDate}
-        goToPreviousMonth={goToPreviousMonth}
-        goToNextMonth={goToNextMonth}
-        selectDate={selectDate}
-      />
-      <DateController
-        calendarDate={calendarDate}
-        selectedDate={selectedDate}
-        selectDate={selectDate}
-      />
+      <Header selectedDate={selectedDate} selectDate={selectDate} />
+      <DateController selectedDate={selectedDate} selectDate={selectDate} />
     </StyledCalendarDate>
   );
 };

--- a/fe/user/src/pages/ShowPage/CalendarDate/index.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/index.tsx
@@ -16,8 +16,10 @@ export const CalendarDate: React.FC = () => {
     <StyledCalendarDate>
       <Header
         calendarDate={calendarDate}
+        selectedDate={selectedDate}
         goToPreviousMonth={goToPreviousMonth}
         goToNextMonth={goToNextMonth}
+        selectDate={selectDate}
       />
       <DateController
         calendarDate={calendarDate}

--- a/fe/user/src/pages/ShowPage/CalendarDate/index.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/index.tsx
@@ -1,12 +1,29 @@
 import styled from '@emotion/styled';
+import { useCalendar } from '~/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/useCalendar';
 import { DateController } from './DateController';
 import { Header } from './Header';
 
 export const CalendarDate: React.FC = () => {
+  const {
+    calendarDate,
+    selectedDate,
+    goToPreviousMonth,
+    goToNextMonth,
+    selectDate,
+  } = useCalendar();
+
   return (
     <StyledCalendarDate>
-      <Header />
-      <DateController />
+      <Header
+        calendarDate={calendarDate}
+        goToPreviousMonth={goToPreviousMonth}
+        goToNextMonth={goToNextMonth}
+      />
+      <DateController
+        calendarDate={calendarDate}
+        selectedDate={selectedDate}
+        selectDate={selectDate}
+      />
     </StyledCalendarDate>
   );
 };

--- a/fe/user/src/utils/dateUtils.ts
+++ b/fe/user/src/utils/dateUtils.ts
@@ -28,3 +28,24 @@ export const getFormattedDateTime = (date: Date) => {
 
   return formattedDateTime;
 };
+
+export const getFirstDay = (year: number, month: number) => {
+  return new Date(year, month - 1, 1).getDay();
+};
+
+export const getLastDate = (year: number, month: number) => {
+  return new Date(year, month, 0).getDate(); // 0일은 지난 달의 마지막 날을 의미합니다.
+};
+
+export const getMonthDates = (firstDay: number, lastDate: number) => {
+  const dates = [];
+
+  for (let i = 1; i <= lastDate; i++) {
+    dates.push({
+      date: i,
+      day: getKoreanWeekdayName((firstDay + i - 1) % 7),
+    });
+  }
+
+  return dates;
+};

--- a/fe/user/src/utils/dateUtils.ts
+++ b/fe/user/src/utils/dateUtils.ts
@@ -37,15 +37,39 @@ export const getLastDate = (year: number, month: number) => {
   return new Date(year, month, 0).getDate(); // 0일은 지난 달의 마지막 날을 의미합니다.
 };
 
-export const getMonthDates = (firstDay: number, lastDate: number) => {
+export const getMonthDates = (date: Date) => {
+  const currentYear = date.getFullYear();
+  const currentMonth = date.getMonth() + 1;
+
+  const lastDate = getLastDate(currentYear, currentMonth);
+
   const dates = [];
 
   for (let i = 1; i <= lastDate; i++) {
-    dates.push({
-      date: i,
-      day: getKoreanWeekdayName((firstDay + i - 1) % 7),
-    });
+    dates.push(new Date(currentYear, currentMonth - 1, i));
   }
 
   return dates;
+};
+
+export const isToday = (date: Date) => {
+  const today = new Date();
+
+  return (
+    date.getFullYear() === today.getFullYear() &&
+    date.getMonth() === today.getMonth() &&
+    date.getDate() === today.getDate()
+  );
+};
+
+export const equalDates = (date1: Date, date2: Date) => {
+  const year1 = date1.getFullYear();
+  const month1 = date1.getMonth();
+  const day1 = date1.getDate();
+
+  const year2 = date2.getFullYear();
+  const month2 = date2.getMonth();
+  const day2 = date2.getDate();
+
+  return year1 === year2 && month1 === month2 && day1 === day2;
 };


### PR DESCRIPTION
## What is this PR? 👓
- 공연 페이지 월, 일자를 보여주고 변경하는 기능입니다.
- 해당 월의 1일부터 마지막 일자까지의 배열을 확보합니다.
- 선택된 일자를 기준으로 -6일부터 +6일까지의 일자 그룹을 보여줍니다.
- 일자 좌우의 버튼으로 일자 그룹을 이동합니다. (일자 그룹을 고정된 3개 기간으로 나눔(네이버스포츠 참고) : 1-13, 10-22, 18-30(19-31))

## Key changes 🔑
- CalendarDate 컴포넌트에서 useCalendar를 호출해 selectedDate, selectDate 상태를 사용했습니다.
- DateController 컴포넌트에 `이번 달 일자 배열 초기화`, `현재 일자 그룹 업데이트 동작`이 구현되어 있습니다. 
- DateGroup 컴포넌트에서 `오늘` 표시, `일자 선택`, `선택된 일자` 표시 구현되어 있습니다.

## To reviewers 👋
- 이전 달로 이동할 때 31일로 선택된 일자를 변경한다. 다음 달로 이동할 때는 1일로 일자를 변경한다.
  - 다른 달로 이동했을 때, 일자 그룹에 선택된 일자가 없으면 사용자가 당황할 것이라고 생각해서 추가한 기능입니다.
- 일자 그룹을 특정 기간으로 고정해서 나누다보니 매직넘버가 있는 점 양해부탁드립니다.