### PR TITLE
공연장 목록 조회 기능 구현

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/controller/VenueController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/controller/VenueController.java
@@ -22,6 +22,7 @@ import kr.codesquad.jazzmeet.venue.dto.response.NearbyVenueResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueAutocompleteResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueCreateResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueDetailResponse;
+import kr.codesquad.jazzmeet.venue.dto.response.VenueListResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenuePinsResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueSearchResponse;
 import kr.codesquad.jazzmeet.venue.service.VenueFacade;
@@ -124,6 +125,17 @@ public class VenueController {
 		VenueSearchResponse venueResponse = venueService.findVenueSearchById(venueId);
 
 		return ResponseEntity.ok(venueResponse);
+	}
+
+	/**
+	 * 공연장 목록 조회 API
+	 */
+	@GetMapping("/api/venues")
+	public ResponseEntity<VenueListResponse> findVenues(@RequestParam(required = false) String word,
+		@RequestParam(defaultValue = "1") @Min(value = 1) int page) {
+		VenueListResponse venues = venueService.findVenuesByWord(word, page);
+
+		return ResponseEntity.ok(venues);
 	}
 
 	/**

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/controller/VenueController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/controller/VenueController.java
@@ -105,6 +105,9 @@ public class VenueController {
 		return ResponseEntity.ok(venue);
 	}
 
+	/**
+	 * 공연장 목록 조회 - 검색 API
+	 */
 	@GetMapping("/api/venues/search")
 	public ResponseEntity<VenueSearchResponse> searchVenueList(
 		@RequestParam String word, @RequestParam(defaultValue = "1") @Min(value = 1) int page) {

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/VenueInfo.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/VenueInfo.java
@@ -1,0 +1,8 @@
+package kr.codesquad.jazzmeet.venue.dto;
+
+public record VenueInfo(
+	Long id,
+	String name,
+	String address
+) {
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/response/VenueListResponse.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/dto/response/VenueListResponse.java
@@ -1,0 +1,13 @@
+package kr.codesquad.jazzmeet.venue.dto.response;
+
+import java.util.List;
+
+import kr.codesquad.jazzmeet.venue.dto.VenueInfo;
+
+public record VenueListResponse(
+	List<VenueInfo> venues,
+	long totalCount,
+	int currentPage,
+	int maxPage
+) {
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/mapper/VenueMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/mapper/VenueMapper.java
@@ -7,13 +7,16 @@ import org.locationtech.jts.geom.Point;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
+import org.springframework.data.domain.Page;
 
 import kr.codesquad.jazzmeet.venue.dto.ShowInfo;
+import kr.codesquad.jazzmeet.venue.dto.VenueInfo;
 import kr.codesquad.jazzmeet.venue.dto.VenueSearch;
 import kr.codesquad.jazzmeet.venue.dto.request.VenueCreateRequest;
 import kr.codesquad.jazzmeet.venue.dto.response.NearbyVenueResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueAutocompleteResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueDetailResponse;
+import kr.codesquad.jazzmeet.venue.dto.response.VenueListResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenuePinsResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueSearchResponse;
 import kr.codesquad.jazzmeet.venue.entity.Venue;
@@ -65,6 +68,11 @@ public interface VenueMapper {
 	@Mapping(target = "longitude", source = "venueSearchData.location.x")
 	@Mapping(target = "showInfo", source = "showInfoList")
 	VenueSearch toVenueSearch(Integer dummy, VenueSearchData venueSearchData, List<ShowInfo> showInfoList);
+
+	@Mapping(target = "venues", source = "venueInfos.content")
+	@Mapping(target = "totalCount", source = "venueInfos.totalElements")
+	@Mapping(target = "maxPage", source = "venueInfos.totalPages")
+	VenueListResponse toVenueListResponse(Page<VenueInfo> venueInfos, int currentPage);
 
 	@Mapping(target = "latitude", source = "location.y")
 	@Mapping(target = "longitude", source = "location.x")

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueFacade.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueFacade.java
@@ -71,8 +71,7 @@ public class VenueFacade {
 		List<VenueHourRequest> venueHours = venueUpdateRequest.venueHours();
 		addVenueHours(venue, venueHours);
 
-		Venue savedVenue = venueService.save(venue);
-		return venueService.findVenue(savedVenue.getId());
+		return venueService.findVenue(venueId);
 	}
 
 	@Transactional

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueService.java
@@ -12,10 +12,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kr.codesquad.jazzmeet.global.error.CustomException;
 import kr.codesquad.jazzmeet.global.error.statuscode.VenueErrorCode;
+import kr.codesquad.jazzmeet.venue.dto.VenueInfo;
 import kr.codesquad.jazzmeet.venue.dto.VenueSearch;
 import kr.codesquad.jazzmeet.venue.dto.response.NearbyVenueResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueAutocompleteResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueDetailResponse;
+import kr.codesquad.jazzmeet.venue.dto.response.VenueListResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenuePinsResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueSearchResponse;
 import kr.codesquad.jazzmeet.venue.entity.Venue;
@@ -35,6 +37,7 @@ import lombok.RequiredArgsConstructor;
 public class VenueService {
 	private static final int PAGE_NUMBER_OFFSET = 1; // 페이지를 1부터 시작하게 하기 위한 offset
 	private static final int PAGE_SIZE = 10;
+	private static final int ADMIN_PAGE_SIZE = 20;
 
 	private final VenueRepository venueRepository;
 	private final VenueQueryRepository venueQueryRepository;
@@ -158,6 +161,14 @@ public class VenueService {
 
 		return VenueMapper.INSTANCE.toVenueSearchResponse(venueSearchList, venueSearchList.size(),
 			PAGE_NUMBER_OFFSET, PAGE_NUMBER_OFFSET);
+	}
+
+	public VenueListResponse findVenuesByWord(String word, int page) {
+		PageRequest pageRequest = PageRequest.of(page - PAGE_NUMBER_OFFSET, ADMIN_PAGE_SIZE);
+
+		Page<VenueInfo> venueInfos = venueQueryRepository.findVenuesByWord(word, pageRequest);
+
+		return VenueMapper.INSTANCE.toVenueListResponse(venueInfos, venueInfos.getNumber() + PAGE_NUMBER_OFFSET);
 	}
 
 	@Transactional

--- a/be/src/test/java/kr/codesquad/jazzmeet/venue/repository/VenueQueryRepositoryTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/venue/repository/VenueQueryRepositoryTest.java
@@ -26,6 +26,7 @@ import kr.codesquad.jazzmeet.image.entity.Image;
 import kr.codesquad.jazzmeet.image.repository.ImageRepository;
 import kr.codesquad.jazzmeet.show.entity.Show;
 import kr.codesquad.jazzmeet.show.repository.ShowRepository;
+import kr.codesquad.jazzmeet.venue.dto.VenueInfo;
 import kr.codesquad.jazzmeet.venue.entity.Venue;
 import kr.codesquad.jazzmeet.venue.entity.VenueImage;
 import kr.codesquad.jazzmeet.venue.util.VenueUtil;
@@ -247,5 +248,52 @@ class VenueQueryRepositoryTest extends IntegrationTestSupport {
 		assertThat(venueDetail.getImages()).hasSize(2)
 			.extracting("url")
 			.contains("image1.url", "image2.url");
+	}
+
+	@Test
+	@DisplayName("Word에 해당하는 공연장 목록을 조회한다")
+	void findVenuesByWord() {
+	    // given
+		Venue venue1 = VenueFixture.createVenue("강남1", "주소1");
+		Venue venue2 = VenueFixture.createVenue("강남2", "주소2");
+		Venue venue3 = VenueFixture.createVenue("마포1", "주소3");
+
+		venueRepository.saveAll(List.of(venue1, venue2, venue3));
+
+		String word = "강남";
+		PageRequest pageRequest = PageRequest.of(0, 20);
+
+		// when
+		Page<VenueInfo> venues = venueQueryRepository.findVenuesByWord(word, pageRequest);
+
+		// then
+		Assertions.assertAll(
+			() -> assertThat(venues.getTotalElements()).isEqualTo(2),
+			() -> assertThat(venues.getContent()).extracting("name")
+			.containsExactly(venue1.getName(), venue2.getName())
+		);
+	}
+
+	@Test
+	@DisplayName("Word가 null이면 모든 공연장 목록을 조회한다")
+	void findVenues() {
+		// given
+		Venue venue1 = VenueFixture.createVenue("강남1", "주소1");
+		Venue venue2 = VenueFixture.createVenue("강남2", "주소2");
+		Venue venue3 = VenueFixture.createVenue("마포1", "주소3");
+
+		venueRepository.saveAll(List.of(venue1, venue2, venue3));
+
+		PageRequest pageRequest = PageRequest.of(0, 20);
+
+		// when
+		Page<VenueInfo> venues = venueQueryRepository.findVenuesByWord(null, pageRequest);
+
+		// then
+		Assertions.assertAll(
+			() -> assertThat(venues.getTotalElements()).isEqualTo(3),
+			() -> assertThat(venues.getContent()).extracting("name")
+				.containsExactly(venue1.getName(), venue2.getName(), venue3.getName())
+		);
 	}
 }


### PR DESCRIPTION
## What is this PR? 👓
- 공연장 목록 조회 API 구현

## To reviewers 👋
- Name을 동적으로 where에 넣어야 하는 조건이 필요해서 `containsInName()`이랑 `containsInAddress()`에 word가 null인 경우에 대한 조건을 넣었습니다.
- 그래서 이 2개가 **or**로 연결되는 부분에서 `NullPointerException`이 발생할 수 있어서 `BooleanBuilder`를 사용한 `containsInNameOrAddress()`를 만들었습니다.
- **VenueMapper**
    - **currentPage**에 1을 더해주는 부분을 `Service`에서 해주는 게 맞는 것 같아서 `toVenueListResponse()`를 파라미터로 **currentPage**를 받게 했는데 괜찮으면 다 통일하면 좋을 것 같아요!