### PR TITLE
공연 수정 API 구현

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/show/controller/ShowController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/controller/ShowController.java
@@ -31,6 +31,9 @@ public class ShowController {
 
 	private final ShowService showService;
 
+	/**
+	 * 진행 중인 공연 조회 API
+	 */
 	@GetMapping("/api/shows/upcoming")
 	public ResponseEntity<List<UpcomingShowResponse>> getUpcomingShows() {
 		LocalDateTime nowTime = LocalDateTime.now();

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/controller/ShowController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/controller/ShowController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -113,5 +114,16 @@ public class ShowController {
 		RegisterShowResponse response = showService.registerShow(venueId, registerShowRequest);
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+	}
+
+	/**
+	 * 공연 수정 API
+	 */
+	@PutMapping("/api/shows/{showId}")
+	public ResponseEntity<ShowDetailResponse> updateShow(@PathVariable Long showId,
+		@Valid @RequestBody RegisterShowRequest request) {
+		ShowDetailResponse response = showService.updateShow(showId, request);
+
+		return ResponseEntity.ok(response);
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/dto/request/RegisterShowRequest.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/dto/request/RegisterShowRequest.java
@@ -10,7 +10,7 @@ import lombok.Builder;
 public record RegisterShowRequest(
 	@NotNull(message = "공연 명을 입력해주세요.")
 	@Size(max = 50, message = "공연 명은 50자까지 가능합니다.")
-	String name,
+	String teamName,
 	@Size(max = 1000, message = "설명은 1000자까지 입력 가능합니다.")
 	String description,
 	@NotNull(message = "poster id를 입력해주세요.")

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/dto/response/ShowDetailResponse.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/dto/response/ShowDetailResponse.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 @Builder
 public record ShowDetailResponse(
 	Long id,
-	String showName,
+	String teamName,
 	String venueName,
 	String description,
 	ShowPoster poster,

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/entity/Show.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/entity/Show.java
@@ -51,4 +51,15 @@ public class Show {
 		this.venue = venue;
 		this.poster = poster;
 	}
+
+	public Show update(String teamName, String description, LocalDateTime startTime, LocalDateTime endTime,
+		Image poster) {
+		this.teamName = teamName;
+		this.description = description;
+		this.startTime = startTime;
+		this.endTime = endTime;
+		this.poster = poster;
+
+		return this;
+	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
@@ -35,7 +35,6 @@ public interface ShowMapper {
 	ShowResponse toShowResponse(Page<ShowSummaryWithVenue> page);
 
 	@Mapping(target = "venueName", source = "venue.name")
-	@Mapping(target = "showName", source = "teamName")
 	ShowDetailResponse toShowDetailResponse(Show show);
 
 	@Mapping(target = "teamName", source = "registerShowRequest.name")

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
@@ -37,6 +37,5 @@ public interface ShowMapper {
 	@Mapping(target = "venueName", source = "venue.name")
 	ShowDetailResponse toShowDetailResponse(Show show);
 
-	@Mapping(target = "teamName", source = "registerShowRequest.name")
 	Show toShow(RegisterShowRequest registerShowRequest, Venue venue, Image poster);
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/ShowQueryRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/ShowQueryRepository.java
@@ -51,6 +51,7 @@ public class ShowQueryRepository {
 			.where(show.startTime.year().eq(date.getYear())
 				.and(show.startTime.month().eq(date.getMonthValue())))
 			.groupBy(show.startTime.dayOfMonth())
+			.orderBy(show.startTime.dayOfMonth().asc())
 			.fetch();
 	}
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowService.java
@@ -144,4 +144,15 @@ public class ShowService {
 
 		return new RegisterShowResponse(savedShow.getId());
 	}
+
+	@Transactional
+	public ShowDetailResponse updateShow(Long showId, RegisterShowRequest request) {
+		Show show = getShowById(showId);
+		Image poster = imageService.findById(request.posterId());
+
+		Show updatedShow = show.update(request.teamName(), request.description(), request.startTime(),
+			request.endTime(), poster);
+
+		return ShowMapper.INSTANCE.toShowDetailResponse(updatedShow);
+	}
 }

--- a/be/src/test/java/kr/codesquad/jazzmeet/show/controller/ShowControllerTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/show/controller/ShowControllerTest.java
@@ -261,4 +261,44 @@ class ShowControllerTest {
 			.andDo(print())
 			.andExpect(status().isBadRequest());
 	}
+
+	@DisplayName("관리자가 공연을 수정한다.")
+	@Test
+	void updateShow() throws Exception {
+		//given
+		Long showId = 1L;
+		RegisterShowRequest request = RegisterShowRequest.builder()
+			.teamName("부기우기 트리오")
+			.description("설명")
+			.posterId(1L)
+			.startTime(LocalDateTime.of(2023, 11, 14, 13, 0))
+			.endTime(LocalDateTime.of(2023, 11, 14, 14, 0))
+			.build();
+
+		ShowDetailResponse response = ShowDetailResponse.builder()
+			.id(1L)
+			.teamName("부기우기 트리오")
+			.description("설명")
+			.venueName("부기우기")
+			.poster(new ShowPoster(1L, "url"))
+			.startTime(LocalDateTime.of(2023, 11, 14, 13, 0))
+			.endTime(LocalDateTime.of(2023, 11, 14, 14, 0))
+			.build();
+
+		when(showService.updateShow(any(), any())).thenReturn(response);
+
+		//when //then
+		mockMvc.perform(
+				put("/api/shows/{showId}", showId)
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(jsonPath("$.id").value(response.id()))
+			.andExpect(jsonPath("$.teamName").value(response.teamName()))
+			.andExpect(jsonPath("$.venueName").value(response.venueName()))
+			.andExpect(jsonPath("$.description").value(response.description()))
+			.andExpect(jsonPath("$.poster.id").value(response.poster().getId()))
+			.andExpect(jsonPath("$.poster.url").value(response.poster().getUrl()));
+	}
 }

--- a/be/src/test/java/kr/codesquad/jazzmeet/show/controller/ShowControllerTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/show/controller/ShowControllerTest.java
@@ -126,7 +126,7 @@ class ShowControllerTest {
 		//given
 		Long showId = 1L;
 		when(showService.getShowDetail(any())).thenReturn(
-			ShowDetailResponse.builder().id(showId).poster(new ShowPoster(1L, "url")).showName("퀄텟").build());
+			ShowDetailResponse.builder().id(showId).poster(new ShowPoster(1L, "url")).teamName("퀄텟").build());
 
 		//when //then
 		mockMvc.perform(
@@ -138,7 +138,7 @@ class ShowControllerTest {
 			.andExpect(jsonPath("$.id").value(1L))
 			.andExpect(jsonPath("$.poster.id").value(1L))
 			.andExpect(jsonPath("$.poster.url").value("url"))
-			.andExpect(jsonPath("$.showName").value("퀄텟"));
+			.andExpect(jsonPath("$.teamName").value("퀄텟"));
 	}
 
 	@DisplayName("관리자가 공연장 페이지에서 공연 등록을 한다.")

--- a/be/src/test/java/kr/codesquad/jazzmeet/show/controller/ShowControllerTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/show/controller/ShowControllerTest.java
@@ -147,7 +147,7 @@ class ShowControllerTest {
 		//given
 		Long venueId = 1L;
 		RegisterShowRequest request = RegisterShowRequest.builder()
-			.name("러스틱재즈 트리오")
+			.teamName("러스틱재즈 트리오")
 			.description("러스틱 재즈 설명")
 			.posterId(1L)
 			.startTime(LocalDateTime.of(2023, 11, 13, 17, 00))
@@ -198,7 +198,7 @@ class ShowControllerTest {
 		Long venueId = 1L;
 
 		RegisterShowRequest request = RegisterShowRequest.builder()
-			.name("아".repeat(51))
+			.teamName("아".repeat(51))
 			.description("러스틱 재즈 설명")
 			.posterId(1L)
 			.startTime(LocalDateTime.of(2023, 11, 13, 17, 00))
@@ -222,7 +222,7 @@ class ShowControllerTest {
 		Long venueId = 1L;
 
 		RegisterShowRequest request = RegisterShowRequest.builder()
-			.name("러스틱 재즈")
+			.teamName("러스틱 재즈")
 			.description("러".repeat(1001))
 			.posterId(1L)
 			.startTime(LocalDateTime.of(2023, 11, 13, 17, 00))
@@ -246,7 +246,7 @@ class ShowControllerTest {
 		Long venueId = 1L;
 
 		RegisterShowRequest request = RegisterShowRequest.builder()
-			.name("러스틱 재즈")
+			.teamName("러스틱 재즈")
 			.description("러스틱 재즈 설명")
 			.startTime(LocalDateTime.of(2023, 11, 13, 17, 00))
 			.endTime(LocalDateTime.of(2023, 11, 13, 19, 00))

--- a/be/src/test/java/kr/codesquad/jazzmeet/show/service/ShowServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/show/service/ShowServiceTest.java
@@ -443,4 +443,38 @@ class ShowServiceTest extends IntegrationTestSupport {
 		//then
 		assertThat(response.id()).isNotNull();
 	}
+
+	@DisplayName("관리자가 show id로 공연을 수정한다.")
+	@Test
+	void updateShow() throws Exception {
+		//given
+		Venue venue = VenueFixture.createVenue("부기우기", "서울 마포구");
+		Show show = ShowFixture.createShow("퀄텟", LocalDateTime.of(2023, 11, 14, 15, 0), venue);
+		showRepository.save(show);
+
+		Image poster = ImageFixture.createImage("url");
+		imageRepository.save(poster);
+
+		Long showId = show.getId();
+		LocalDateTime startTime = LocalDateTime.of(2023, 11, 14, 18, 0);
+		RegisterShowRequest request = RegisterShowRequest.builder()
+			.teamName("수정된 팀 명")
+			.description("수정됨")
+			.posterId(poster.getId())
+			.startTime(startTime)
+			.endTime(startTime.plusHours(2))
+			.build();
+
+		//when
+		ShowDetailResponse response = showService.updateShow(showId, request);
+
+		//then
+		Assertions.assertAll(
+			() -> assertThat(response)
+				.extracting("teamName", "venueName", "description", "startTime", "endTime")
+				.contains("수정된 팀 명", "부기우기", "수정됨", startTime, startTime.plusHours(2)),
+			() -> assertThat(response.poster())
+				.extracting("url")
+				.isEqualTo("url"));
+	}
 }

--- a/be/src/test/java/kr/codesquad/jazzmeet/show/service/ShowServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/show/service/ShowServiceTest.java
@@ -202,9 +202,10 @@ class ShowServiceTest extends IntegrationTestSupport {
 		Venue venue1 = VenueFixture.createVenue("부기우기", "경기도 고양시");
 		Venue venue2 = VenueFixture.createVenue("클럽에반스", "경기도 고양시");
 
-		Show show1 = ShowFixture.createShow("부기우기 트리오1", LocalDateTime.of(2023, 11, 1, 18, 00), venue1);
+		Show show1 = ShowFixture.createShow("Entry55 트리오1", LocalDateTime.of(2023, 11, 3, 18, 00), venue2);
 		Show show2 = ShowFixture.createShow("부기우기 트리오2", LocalDateTime.of(2023, 11, 2, 20, 00), venue1);
-		Show show3 = ShowFixture.createShow("Entry55 트리오1", LocalDateTime.of(2023, 11, 3, 18, 00), venue2);
+		Show show3 = ShowFixture.createShow("부기우기 트리오1", LocalDateTime.of(2023, 11, 1, 18, 00), venue1);
+
 		showRepository.saveAll(List.of(show1, show2, show3));
 
 		//when

--- a/be/src/test/java/kr/codesquad/jazzmeet/show/service/ShowServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/show/service/ShowServiceTest.java
@@ -391,7 +391,7 @@ class ShowServiceTest extends IntegrationTestSupport {
 		//then
 		Assertions.assertAll(
 			() -> assertThat(showDetail)
-				.extracting("id", "showName", "venueName", "startTime", "endTime")
+				.extracting("id", "teamName", "venueName", "startTime", "endTime")
 				.contains(show.getId(), "Entry55 퀄텟1", "부기우기", LocalDateTime.of(2023, 11, 1, 20, 00),
 					LocalDateTime.of(2023, 11, 1, 20, 00)),
 

--- a/be/src/test/java/kr/codesquad/jazzmeet/show/service/ShowServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/show/service/ShowServiceTest.java
@@ -430,7 +430,7 @@ class ShowServiceTest extends IntegrationTestSupport {
 
 		Long venueId = venue.getId();
 		RegisterShowRequest request = RegisterShowRequest.builder()
-			.name("Entry55 퀄텟")
+			.teamName("Entry55 퀄텟")
 			.posterId(poster.getId())
 			.description("description")
 			.startTime(LocalDateTime.of(2023, 11, 13, 11, 50))


### PR DESCRIPTION
## What is this PR? 👓
공연 수정 API를 구현했습니다.

## Key changes 🔑
show 쪽에 teamName, name, showName이 혼용되어 사용되고 있어서 teamName으로 통일되게 수정하고 API 명세서도 변경했습니다.    
월간 공연 일정 유무 조회에서 날짜로 정렬하기도 추가했습니다.

