### PR TITLE
S3에서 필요없는 이미지 삭제 기능

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/JazzMeetApplication.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/JazzMeetApplication.java
@@ -2,7 +2,9 @@ package kr.codesquad.jazzmeet;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class JazzMeetApplication {
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ImageErrorCode.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ImageErrorCode.java
@@ -9,6 +9,7 @@ public enum ImageErrorCode implements StatusCode{
 
 	// -- [Image] -- //
 	IMAGE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다."),
+	IMAGE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 삭제에 실패했습니다."),
 	NOT_FOUND_IMAGE(HttpStatus.NOT_FOUND, "해당하는 이미지가 없습니다."),
 	WRONG_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 파일 형식입니다."),
 	IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지는 최대 10개까지 등록할 수 있습니다.");

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/entity/Image.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/entity/Image.java
@@ -42,7 +42,11 @@ public class Image {
 		return url;
 	}
 
-	public void updateStatus(ImageStatus status) {
-		this.status = status;
+	public void delete() {
+		this.status = ImageStatus.DELETED;
+	}
+
+	public void register() {
+		this.status = ImageStatus.REGISTERED;
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/entity/Image.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/entity/Image.java
@@ -1,7 +1,5 @@
 package kr.codesquad.jazzmeet.image.entity;
 
-import java.time.LocalDateTime;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -9,13 +7,14 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import kr.codesquad.jazzmeet.global.time.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Image {
+public class Image extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -24,14 +23,11 @@ public class Image {
 	@Enumerated(value = EnumType.STRING)
 	@Column(nullable = false, length = 12)
 	private ImageStatus status;
-	@Column(nullable = false)
-	private LocalDateTime createdAt;
 
 	@Builder
-	public Image(String url, ImageStatus status, LocalDateTime createdAt) {
+	public Image(String url, ImageStatus status) {
 		this.url = url;
 		this.status = status;
-		this.createdAt = createdAt;
 	}
 
 	public Long getId() {

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/entity/Image.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/entity/Image.java
@@ -18,7 +18,7 @@ public class Image extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-	@Column(nullable = false, length = 500)
+	@Column(nullable = false, unique = true, length = 500)
 	private String url;
 	@Enumerated(value = EnumType.STRING)
 	@Column(nullable = false, length = 12)

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/mapper/ImageMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/mapper/ImageMapper.java
@@ -1,7 +1,5 @@
 package kr.codesquad.jazzmeet.image.mapper;
 
-import java.time.LocalDateTime;
-
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
@@ -13,5 +11,5 @@ public interface ImageMapper {
 
 	ImageMapper INSTANCE = Mappers.getMapper(ImageMapper.class);
 
-	Image toImage(String url, ImageStatus status, LocalDateTime createdAt);
+	Image toImage(String url, ImageStatus status);
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/repository/ImageQueryRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/repository/ImageQueryRepository.java
@@ -1,0 +1,24 @@
+package kr.codesquad.jazzmeet.image.repository;
+
+import static kr.codesquad.jazzmeet.image.entity.QImage.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class ImageQueryRepository {
+
+	private final JPAQueryFactory query;
+
+	public void deleteAllInUrls(List<String> urls) {
+		query.delete(image)
+			.where(image.url.in(urls))
+			.execute();
+	}
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/repository/ImageQueryRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/repository/ImageQueryRepository.java
@@ -2,12 +2,16 @@ package kr.codesquad.jazzmeet.image.repository;
 
 import static kr.codesquad.jazzmeet.image.entity.QImage.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import kr.codesquad.jazzmeet.image.entity.Image;
+import kr.codesquad.jazzmeet.image.entity.ImageStatus;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -15,6 +19,20 @@ import lombok.RequiredArgsConstructor;
 public class ImageQueryRepository {
 
 	private final JPAQueryFactory query;
+
+	public List<Image> findAllNotRegistered(LocalDate date) {
+		return query.selectFrom(image)
+			.where(image.status.eq(ImageStatus.DELETED)
+				.or(image.status.eq(ImageStatus.UNREGISTERED)
+					.and(isDifferentDate(date))
+				)
+			)
+			.fetch();
+	}
+
+	private BooleanExpression isDifferentDate(LocalDate date) {
+		return image.createdAt.dayOfYear().ne(date.getDayOfYear());
+	}
 
 	public void deleteAllInUrls(List<String> urls) {
 		query.delete(image)

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/repository/ImageRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/repository/ImageRepository.java
@@ -1,6 +1,5 @@
 package kr.codesquad.jazzmeet.image.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,6 +12,4 @@ import kr.codesquad.jazzmeet.image.entity.ImageStatus;
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
 	Optional<Image> findByIdAndStatusNot(Long imageId, ImageStatus status);
-
-	List<Image> findAllByStatusNot(ImageStatus status);
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/repository/ImageRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/repository/ImageRepository.java
@@ -1,5 +1,6 @@
 package kr.codesquad.jazzmeet.image.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,4 +13,6 @@ import kr.codesquad.jazzmeet.image.entity.ImageStatus;
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
 	Optional<Image> findByIdAndStatusNot(Long imageId, ImageStatus status);
+
+	List<Image> findAllByStatusNot(ImageStatus status);
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/repository/S3ImageHandler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/repository/S3ImageHandler.java
@@ -1,5 +1,7 @@
 package kr.codesquad.jazzmeet.image.repository;
 
+import static com.amazonaws.services.s3.model.DeleteObjectsRequest.KeyVersion;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -12,6 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 
@@ -84,5 +87,17 @@ public class S3ImageHandler {
 			throw new CustomException(ImageErrorCode.WRONG_IMAGE_FORMAT);
 		}
 		return fileName.substring(lastDotIndex + 1).toLowerCase();
+	}
+
+	public void deleteImages(List<String> imageUrls) {
+		DeleteObjectsRequest deleteObjectsRequest = new DeleteObjectsRequest(bucket);
+		ArrayList<KeyVersion> keys = new ArrayList<>();
+		imageUrls.forEach(url -> {
+			KeyVersion keyVersion = new KeyVersion(url);
+			keys.add(keyVersion);
+		});
+		deleteObjectsRequest.setKeys(keys);
+
+		amazonS3Client.deleteObjects(deleteObjectsRequest);
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/repository/S3ImageHandler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/repository/S3ImageHandler.java
@@ -27,7 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 public class S3ImageHandler {
 
 	private static final String IMAGE_DIRECTORY = "images/";
-	public static final int FILE_NAME_SEPERATE_INDEX = 4;
+	public static final int FILE_NAME_SEPARATE_INDEX = 4;
 
 	private final AmazonS3Client amazonS3Client;
 
@@ -93,7 +93,7 @@ public class S3ImageHandler {
 	public List<String> deleteImages(List<String> imageUrls) {
 		try {
 			String[] urls = imageUrls.stream()
-				.map(url -> IMAGE_DIRECTORY + url.split("/")[FILE_NAME_SEPERATE_INDEX])
+				.map(url -> IMAGE_DIRECTORY + url.split("/")[FILE_NAME_SEPARATE_INDEX])
 				.toArray(String[]::new);
 			DeleteObjectsRequest deleteObjectsRequest = new DeleteObjectsRequest(bucket).withKeys(urls);
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/repository/S3ImageHandler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/repository/S3ImageHandler.java
@@ -90,14 +90,18 @@ public class S3ImageHandler {
 	}
 
 	public void deleteImages(List<String> imageUrls) {
-		DeleteObjectsRequest deleteObjectsRequest = new DeleteObjectsRequest(bucket);
-		ArrayList<KeyVersion> keys = new ArrayList<>();
-		imageUrls.forEach(url -> {
-			KeyVersion keyVersion = new KeyVersion(url);
-			keys.add(keyVersion);
-		});
-		deleteObjectsRequest.setKeys(keys);
+		try {
+			DeleteObjectsRequest deleteObjectsRequest = new DeleteObjectsRequest(bucket);
+			ArrayList<KeyVersion> keys = new ArrayList<>();
+			imageUrls.forEach(url -> {
+				KeyVersion keyVersion = new KeyVersion(url);
+				keys.add(keyVersion);
+			});
+			deleteObjectsRequest.setKeys(keys);
 
-		amazonS3Client.deleteObjects(deleteObjectsRequest);
+			amazonS3Client.deleteObjects(deleteObjectsRequest);
+		} catch (Exception e) {
+			throw new CustomException(ImageErrorCode.IMAGE_DELETE_ERROR);
+		}
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/service/CloudService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/service/CloudService.java
@@ -18,7 +18,7 @@ public class CloudService {
 		return s3ImageHandler.uploadImages(multipartFiles);
 	}
 
-	public void deleteImages(List<String> imageUrls) {
-		s3ImageHandler.deleteImages(imageUrls);
+	public List<String> deleteImages(List<String> imageUrls) {
+		return s3ImageHandler.deleteImages(imageUrls);
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/service/CloudService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/service/CloudService.java
@@ -17,4 +17,8 @@ public class CloudService {
 	public List<String> uploadImages(List<MultipartFile> multipartFiles) {
 		return s3ImageHandler.uploadImages(multipartFiles);
 	}
+
+	public void deleteImages(List<String> imageUrls) {
+		s3ImageHandler.deleteImages(imageUrls);
+	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageScheduler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageScheduler.java
@@ -1,0 +1,25 @@
+package kr.codesquad.jazzmeet.image.service;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class ImageScheduler {
+
+	private final ImageService imageService;
+	private final CloudService cloudService;
+
+	@Scheduled(cron = "0 0 12 ? * MON")
+	public void deleteNotRegisteredImages() {
+		List<String> imageUrls = imageService.findNotRegisteredImageUrls();
+
+		List<String> deletedImageUrls = cloudService.deleteImages(imageUrls);
+
+		imageService.deleteImagesByUrls(deletedImageUrls);
+	}
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageScheduler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageScheduler.java
@@ -14,7 +14,7 @@ public class ImageScheduler {
 	private final ImageService imageService;
 	private final CloudService cloudService;
 
-	@Scheduled(cron = "0 0 12 ? * MON")
+	@Scheduled(cron = "0 0 12 ? * MON")	// 매주 월요일 12시 00분 00초
 	public void deleteNotRegisteredImages() {
 		List<String> imageUrls = imageService.findNotRegisteredImageUrls();
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
@@ -40,14 +40,9 @@ public class ImageService {
 	}
 
 	@Transactional
-	public void registerImage(Image image) {
-		image.updateStatus(ImageStatus.REGISTERED);
-	}
-
-	@Transactional
 	public void deleteImage(Long imageId) {
 		Image image = findById(imageId);
-		image.updateStatus(ImageStatus.DELETED);
+		image.delete();
 	}
 
 	public Image findById(Long imageId) {

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
@@ -45,4 +45,11 @@ public class ImageService {
 		return imageRepository.findByIdAndStatusNot(imageId, ImageStatus.DELETED)
 			.orElseThrow(() -> new CustomException(ImageErrorCode.NOT_FOUND_IMAGE));
 	}
+
+	public List<String> findAllStatusNotRegistered() {
+		List<Image> images = imageRepository.findAllByStatusNot(ImageStatus.REGISTERED);
+		return images.stream()
+			.map(Image::getUrl)
+			.toList();
+	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
@@ -1,5 +1,6 @@
 package kr.codesquad.jazzmeet.image.service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -49,7 +50,9 @@ public class ImageService {
 	}
 
 	public List<String> findNotRegisteredImageUrls() {
-		List<Image> images = imageRepository.findAllByStatusNot(ImageStatus.REGISTERED);
+		LocalDate today = LocalDate.now();
+		// UNREGISTERED 상태는 created_at이 today와 다른 데이터 조회
+		List<Image> images = imageQueryRepository.findAllNotRegistered(today);
 		return images.stream()
 			.map(Image::getUrl)
 			.toList();

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
@@ -11,6 +11,7 @@ import kr.codesquad.jazzmeet.image.dto.response.ImageIdsResponse;
 import kr.codesquad.jazzmeet.image.entity.Image;
 import kr.codesquad.jazzmeet.image.entity.ImageStatus;
 import kr.codesquad.jazzmeet.image.mapper.ImageMapper;
+import kr.codesquad.jazzmeet.image.repository.ImageQueryRepository;
 import kr.codesquad.jazzmeet.image.repository.ImageRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class ImageService {
 
 	private final ImageRepository imageRepository;
+	private final ImageQueryRepository imageQueryRepository;
 
 	@Transactional
 	public ImageIdsResponse saveImages(List<String> imageUrls) {
@@ -46,10 +48,15 @@ public class ImageService {
 			.orElseThrow(() -> new CustomException(ImageErrorCode.NOT_FOUND_IMAGE));
 	}
 
-	public List<String> findAllStatusNotRegistered() {
+	public List<String> findNotRegisteredImageUrls() {
 		List<Image> images = imageRepository.findAllByStatusNot(ImageStatus.REGISTERED);
 		return images.stream()
 			.map(Image::getUrl)
 			.toList();
+	}
+
+	@Transactional
+	public void deleteImagesByUrls(List<String> urls) {
+		imageQueryRepository.deleteAllInUrls(urls);
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
@@ -1,6 +1,5 @@
 package kr.codesquad.jazzmeet.image.service;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -25,10 +24,7 @@ public class ImageService {
 	@Transactional
 	public ImageIdsResponse saveImages(List<String> imageUrls) {
 		List<Image> images = imageUrls.stream()
-			.map(url -> {
-				LocalDateTime now = LocalDateTime.now();
-				return ImageMapper.INSTANCE.toImage(url, ImageStatus.UNREGISTERED, now);
-			})
+			.map(url -> ImageMapper.INSTANCE.toImage(url, ImageStatus.UNREGISTERED))
 			.toList();
 
 		List<Image> saveImages = imageRepository.saveAll(images);

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/entity/Show.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/entity/Show.java
@@ -13,7 +13,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import kr.codesquad.jazzmeet.image.entity.Image;
-import kr.codesquad.jazzmeet.image.entity.ImageStatus;
 import kr.codesquad.jazzmeet.venue.entity.Venue;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -64,10 +63,10 @@ public class Show {
 	}
 
 	private void registerPoster() {
-		this.poster.updateStatus(ImageStatus.REGISTERED);
+		this.poster.register();
 	}
 
 	public void deletePoster() {
-		this.poster.updateStatus(ImageStatus.DELETED);
+		this.poster.delete();
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/Venue.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/Venue.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import kr.codesquad.jazzmeet.image.entity.Image;
 import kr.codesquad.jazzmeet.show.entity.Show;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -71,9 +72,17 @@ public class Venue {
 		this.description = description;
 		this.location = location;
 		this.thumbnailUrl = thumbnailUrl;
-		this.images.clear();
 		this.links.clear();
 		this.venueHours.clear();
+		deleteImages();
+		this.images.clear();
+	}
+
+	public void deleteImages() {
+		for (VenueImage venueImage : images) {
+			Image image = venueImage.getImage();
+			image.delete();
+		}
 	}
 
 	// 연관관계 편의 메서드

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueFacade.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueFacade.java
@@ -108,7 +108,7 @@ public class VenueFacade {
 		AtomicLong imageOrder = new AtomicLong();
 		imageIds.forEach(imageId -> {
 			Image image = imageService.findById(imageId);
-			imageService.registerImage(image);
+			image.register();
 			VenueImage venueImage = VenueImage.builder()
 				.imageOrder(imageOrder.incrementAndGet())
 				.image(image)

--- a/be/src/test/java/kr/codesquad/jazzmeet/fixture/ImageFixture.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/fixture/ImageFixture.java
@@ -1,7 +1,5 @@
 package kr.codesquad.jazzmeet.fixture;
 
-import java.time.LocalDateTime;
-
 import kr.codesquad.jazzmeet.image.entity.Image;
 import kr.codesquad.jazzmeet.image.entity.ImageStatus;
 
@@ -10,7 +8,6 @@ public class ImageFixture {
 		return Image.builder()
 			.url(imageUrl)
 			.status(ImageStatus.UNREGISTERED)
-			.createdAt(LocalDateTime.now())
 			.build();
 	}
 }

--- a/be/src/test/java/kr/codesquad/jazzmeet/fixture/ImageFixture.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/fixture/ImageFixture.java
@@ -10,4 +10,11 @@ public class ImageFixture {
 			.status(ImageStatus.UNREGISTERED)
 			.build();
 	}
+
+	public static Image createImage(String imageUrl, ImageStatus status) {
+		return Image.builder()
+			.url(imageUrl)
+			.status(status)
+			.build();
+	}
 }

--- a/be/src/test/java/kr/codesquad/jazzmeet/fixture/ShowFixture.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/fixture/ShowFixture.java
@@ -20,7 +20,7 @@ public class ShowFixture {
 	public static Show createShow(String teamName, LocalDateTime time, Venue venue) {
 		return Show.builder()
 			.teamName(teamName)
-			.poster(new Image("image.url", ImageStatus.REGISTERED, LocalDateTime.now()))
+			.poster(new Image("image.url", ImageStatus.REGISTERED))
 			.startTime(time)
 			.endTime(time)
 			.venue(venue)

--- a/be/src/test/java/kr/codesquad/jazzmeet/image/repository/ImageRepositoryTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/image/repository/ImageRepositoryTest.java
@@ -1,0 +1,73 @@
+package kr.codesquad.jazzmeet.image.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.codesquad.jazzmeet.IntegrationTestSupport;
+import kr.codesquad.jazzmeet.fixture.ImageFixture;
+import kr.codesquad.jazzmeet.image.entity.Image;
+import kr.codesquad.jazzmeet.image.entity.ImageStatus;
+
+class ImageRepositoryTest extends IntegrationTestSupport {
+
+	@Autowired
+	ImageQueryRepository imageQueryRepository;
+
+	@Autowired
+	ImageRepository imageRepository;
+
+	@AfterEach
+	void dbClean() {
+		imageRepository.deleteAllInBatch();
+	}
+
+	@Test
+	@DisplayName("이미지의 상태가 DELETED 이거나 상태가 UNREGISTERED 이면서 생성일자가 오늘이 아닌 이미지를 모두 조회한다")
+	void findAllStatusNotRegistered() {
+	    // given
+		Image image1 = ImageFixture.createImage("url1", ImageStatus.REGISTERED);
+		Image image2 = ImageFixture.createImage("url2", ImageStatus.UNREGISTERED);
+		Image image3 = ImageFixture.createImage("url3", ImageStatus.DELETED);
+
+		imageRepository.saveAll(List.of(image1, image2, image3));
+
+		LocalDate today = LocalDate.now();
+		LocalDate yesterday = LocalDate.of(today.getYear(), today.getMonth(), today.getDayOfMonth() - 1);
+
+		// when
+		List<Image> images = imageQueryRepository.findAllNotRegistered(yesterday);
+
+		// then
+		assertThat(images).extracting("url")
+			.containsExactly("url2", "url3");
+	}
+
+	@Test
+	@DisplayName("URL의 리스트를 입력 받아서 URL에 해당하는 이미지를 모두 삭제한다")
+	@Transactional
+	void deleteImagesByUrls() {
+	    // given
+		Image image1 = ImageFixture.createImage("url1");
+		Image image2 = ImageFixture.createImage("url2");
+		Image image3 = ImageFixture.createImage("url3");
+
+		imageRepository.saveAll(List.of(image1, image2, image3));
+		List<String> imageUrls = List.of(image1.getUrl(), image2.getUrl());
+
+		// when
+		imageQueryRepository.deleteAllInUrls(imageUrls);
+
+	    // then
+		List<Image> images = imageRepository.findAll();
+		assertThat(images).extracting("url")
+			.containsExactly("url3");
+	}
+}

--- a/be/src/test/java/kr/codesquad/jazzmeet/image/repository/S3ImageHandlerTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/image/repository/S3ImageHandlerTest.java
@@ -2,6 +2,8 @@ package kr.codesquad.jazzmeet.image.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +25,7 @@ class S3ImageHandlerTest extends IntegrationTestSupport {
 		MockMultipartFile file = new MockMultipartFile("image", "fileName.jpg", "multipart/form-data", content);
 
 		// when
-		String imageUrl = s3ImageHandler.uploadImage(file, "/test");
+		String imageUrl = s3ImageHandler.uploadImage(file, "test/");
 
 		// then
 		assertThat(imageUrl).isNotNull();
@@ -38,9 +40,27 @@ class S3ImageHandlerTest extends IntegrationTestSupport {
 		MockMultipartFile file2 = new MockMultipartFile("image", "", "multipart/form-data", content);
 
 		// when then
-		assertThatThrownBy(() -> s3ImageHandler.uploadImage(file1, "/test"))
+		assertThatThrownBy(() -> s3ImageHandler.uploadImage(file1, "test/"))
 			.isInstanceOf(CustomException.class);
-		assertThatThrownBy(() -> s3ImageHandler.uploadImage(file2, "/test"))
+		assertThatThrownBy(() -> s3ImageHandler.uploadImage(file2, "test/"))
 			.isInstanceOf(CustomException.class);
+	}
+
+	@Test
+	@DisplayName("URL 리스트를 입력 받아서 S3에서 URL에 해당하는 이미지를 삭제하고 URL 리스트를 반환한다")
+	void deleteImages() {
+	    // given
+		byte[] content = "TEST CONTENT".getBytes();
+		MockMultipartFile file1 = new MockMultipartFile("image", "file1.jpg", "multipart/form-data", content);
+		MockMultipartFile file2 = new MockMultipartFile("image", "file2.jpg", "multipart/form-data", content);
+
+		String imageUrl1 = s3ImageHandler.uploadImage(file1, "test/");
+		String imageUrl2 = s3ImageHandler.uploadImage(file2, "test/");
+
+	    // when
+		List<String> deletedImageUrls = s3ImageHandler.deleteImages(List.of(imageUrl1, imageUrl2));
+
+		// then
+		assertThat(deletedImageUrls).hasSize(2);
 	}
 }

--- a/be/src/test/java/kr/codesquad/jazzmeet/image/service/ImageServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/image/service/ImageServiceTest.java
@@ -68,19 +68,4 @@ class ImageServiceTest extends IntegrationTestSupport {
 		assertThatThrownBy(() -> imageService.deleteImage(wrongId))
 			.isInstanceOf(CustomException.class);
 	}
-
-	@Test
-	@DisplayName("이미지의 상태를 등록 상태로 변경한다")
-	void registerImage() {
-		// given
-		Image image = ImageFixture.createImage("imgUrl");
-		Image savedImage = imageRepository.save(image);
-
-		// when
-		imageService.registerImage(savedImage);
-
-		// then
-		Image registeredImage = imageRepository.save(savedImage);
-		assertThat(registeredImage).extracting("status").isEqualTo(ImageStatus.REGISTERED);
-	}
 }

--- a/be/src/test/java/kr/codesquad/jazzmeet/image/service/ImageServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/image/service/ImageServiceTest.java
@@ -68,4 +68,21 @@ class ImageServiceTest extends IntegrationTestSupport {
 		assertThatThrownBy(() -> imageService.deleteImage(wrongId))
 			.isInstanceOf(CustomException.class);
 	}
+
+	@Test
+	@DisplayName("이미지의 상태가 REGISTERED가 아닌 이미지를 모두 조회하고 url의 목록으로 반환한다")
+	void findAllStatusNotRegistered() {
+	    // given
+		Image image1 = ImageFixture.createImage("url1", ImageStatus.REGISTERED);
+		Image image2 = ImageFixture.createImage("url2", ImageStatus.UNREGISTERED);
+		Image image3 = ImageFixture.createImage("url3", ImageStatus.DELETED);
+
+		imageRepository.saveAll(List.of(image1, image2, image3));
+
+		// when
+		List<String> imageUrls = imageService.findAllStatusNotRegistered();
+
+		// then
+		assertThat(imageUrls).containsExactly("url2", "url3");
+	}
 }

--- a/be/src/test/java/kr/codesquad/jazzmeet/image/service/ImageServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/image/service/ImageServiceTest.java
@@ -80,9 +80,29 @@ class ImageServiceTest extends IntegrationTestSupport {
 		imageRepository.saveAll(List.of(image1, image2, image3));
 
 		// when
-		List<String> imageUrls = imageService.findAllStatusNotRegistered();
+		List<String> imageUrls = imageService.findNotRegisteredImageUrls();
 
 		// then
 		assertThat(imageUrls).containsExactly("url2", "url3");
+	}
+
+	@Test
+	@DisplayName("URL의 리스트를 입력 받아서 URL에 해당하는 이미지를 모두 삭제한다")
+	void deleteImagesByUrls() {
+	    // given
+		Image image1 = ImageFixture.createImage("url1");
+		Image image2 = ImageFixture.createImage("url2");
+		Image image3 = ImageFixture.createImage("url3");
+
+		imageRepository.saveAll(List.of(image1, image2, image3));
+		List<String> imageUrls = List.of(image1.getUrl(), image2.getUrl());
+
+		// when
+		imageService.deleteImagesByUrls(imageUrls);
+
+	    // then
+		List<Image> images = imageRepository.findAll();
+		assertThat(images).extracting("url")
+			.containsExactly("url3");
 	}
 }

--- a/be/src/test/java/kr/codesquad/jazzmeet/image/service/ImageServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/image/service/ImageServiceTest.java
@@ -68,41 +68,4 @@ class ImageServiceTest extends IntegrationTestSupport {
 		assertThatThrownBy(() -> imageService.deleteImage(wrongId))
 			.isInstanceOf(CustomException.class);
 	}
-
-	@Test
-	@DisplayName("이미지의 상태가 REGISTERED가 아닌 이미지를 모두 조회하고 url의 목록으로 반환한다")
-	void findAllStatusNotRegistered() {
-	    // given
-		Image image1 = ImageFixture.createImage("url1", ImageStatus.REGISTERED);
-		Image image2 = ImageFixture.createImage("url2", ImageStatus.UNREGISTERED);
-		Image image3 = ImageFixture.createImage("url3", ImageStatus.DELETED);
-
-		imageRepository.saveAll(List.of(image1, image2, image3));
-
-		// when
-		List<String> imageUrls = imageService.findNotRegisteredImageUrls();
-
-		// then
-		assertThat(imageUrls).containsExactly("url2", "url3");
-	}
-
-	@Test
-	@DisplayName("URL의 리스트를 입력 받아서 URL에 해당하는 이미지를 모두 삭제한다")
-	void deleteImagesByUrls() {
-	    // given
-		Image image1 = ImageFixture.createImage("url1");
-		Image image2 = ImageFixture.createImage("url2");
-		Image image3 = ImageFixture.createImage("url3");
-
-		imageRepository.saveAll(List.of(image1, image2, image3));
-		List<String> imageUrls = List.of(image1.getUrl(), image2.getUrl());
-
-		// when
-		imageService.deleteImagesByUrls(imageUrls);
-
-	    // then
-		List<Image> images = imageRepository.findAll();
-		assertThat(images).extracting("url")
-			.containsExactly("url3");
-	}
 }


### PR DESCRIPTION
## What is this PR? 👓
- 스케줄러를 이용해서 주기적으로 S3에서 필요없는 이미지 삭제하는 기능 구현

## Key changes 🔑
- **Image**의 `delete()`, `register()`의 **ImageStatus** 파라미터를 없애서 **Image**에서만 의존하도록 수정했습니다.
- **Image**의 `url` 필드에 `unique` 조건을 추가했습니다.
- **Scheduling**을 사용하는 **ImageScheduler** 클래스를 만들었습니다.
    - **JazzMeetApplication** 클래스에 `@EnableScheduling`를 붙이면 **Scheduling**을 사용할 수 있습니다.

## To reviewers 👋
- 삭제하는 이미지는 **DELETED** 상태 또는 **UNREGISTERED** 상태이면서 `created_at`이 오늘이 아니면 삭제하도록 했습니다.
    - **DELETED**는 모두 삭제
    - **UNREGISTERED**는 **REGISTERED**가 되기 전에 삭제 되지 않도록 하기 위해서 `created_at`이 오늘이 아니면 삭제
- 스케줄러는 일단 매주 월요일 낮 12시에 실행하도록 했습니다. 추후 수정 가능
    - 12시인 이유는 00시에 실행하게 되면 11시59분에 이미지를 등록한 상태에서 등록 전에 하루가 지나면 이미지가 삭제 되어버릴 수 있기 때문에
- https://www.notion.so/API-646a4cbd004b433492eeef5f08985618?p=3661af54ce3f49d2aab765916d6020ac&pm=s