### PR TITLE
공연 페이지 날짜 표시방법 변경

### DIFF
--- a/fe/user/src/constants/ELEMENT_SIZE.ts
+++ b/fe/user/src/constants/ELEMENT_SIZE.ts
@@ -1,0 +1,1 @@
+export const DATE_BUTTON_WIDTH = 92;

--- a/fe/user/src/pages/ShowPage/CalendarDate/DateController/DateGroup.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/DateController/DateGroup.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled';
 import { useEffect, useRef } from 'react';
+import { DATE_BUTTON_WIDTH } from '~/constants/ELEMENT_SIZE';
 import { equalDates, getKoreanWeekdayName } from '~/utils/dateUtils';
 
 type Props = {
+  dateGroupRef: React.RefObject<HTMLDivElement>;
   dates: Date[];
   centerDateIndex: number;
   showDates: number[];
@@ -11,16 +13,15 @@ type Props = {
 };
 
 export const DateGroup: React.FC<Props> = ({
+  dateGroupRef,
   dates,
   centerDateIndex,
   showDates,
   selectedDate,
   selectDate,
 }) => {
-  const dateGroupRef = useRef<HTMLDivElement>(null);
   const dateContainerRef = useRef<HTMLUListElement>(null);
   const today = new Date();
-  const DATE_BUTTON_WIDTH = 92;
 
   useEffect(() => {
     if (dateGroupRef.current && dateContainerRef.current) {
@@ -38,7 +39,7 @@ export const DateGroup: React.FC<Props> = ({
 
       dateContainerRef.current.style.transform = `translateX(${scrollX}px)`;
     }
-  }, [centerDateIndex]);
+  }, [centerDateIndex, dateGroupRef]);
 
   return (
     <StyledDateGroup ref={dateGroupRef}>

--- a/fe/user/src/pages/ShowPage/CalendarDate/DateController/DateGroup.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/DateController/DateGroup.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled';
+import { useEffect, useRef } from 'react';
 import { equalDates, getKoreanWeekdayName } from '~/utils/dateUtils';
 
 type Props = {
   dates: Date[];
+  centerDateIndex: number;
   showDates: number[];
   selectedDate: Date;
   selectDate: (date: Date) => void;
@@ -10,46 +12,74 @@ type Props = {
 
 export const DateGroup: React.FC<Props> = ({
   dates,
+  centerDateIndex,
   showDates,
   selectedDate,
   selectDate,
 }) => {
+  const dateGroupRef = useRef<HTMLDivElement>(null);
+  const dateContainerRef = useRef<HTMLUListElement>(null);
   const today = new Date();
+  const DATE_BUTTON_WIDTH = 92;
+
+  useEffect(() => {
+    if (dateGroupRef.current && dateContainerRef.current) {
+      const dateGroupWidth = dateGroupRef.current.offsetWidth;
+      const dateContainerWidth = dateContainerRef.current.scrollWidth;
+
+      const translateX =
+        dateGroupWidth / 2 - centerDateIndex * DATE_BUTTON_WIDTH;
+      const scrollX =
+        translateX > 0
+          ? 0
+          : translateX + dateContainerWidth - dateGroupWidth < 0
+          ? dateGroupWidth - dateContainerWidth
+          : translateX;
+
+      dateContainerRef.current.style.transform = `translateX(${scrollX}px)`;
+    }
+  }, [centerDateIndex]);
 
   return (
-    <StyledDateGroup>
-      {dates.map((date: Date) => {
-        const day = getKoreanWeekdayName(date.getDay());
-        const dateNumber = date.getDate();
+    <StyledDateGroup ref={dateGroupRef}>
+      <StyledDateContainer ref={dateContainerRef}>
+        {dates.map((date: Date) => {
+          const day = getKoreanWeekdayName(date.getDay());
+          const dateNumber = date.getDate();
 
-        return (
-          <li key={dateNumber}>
-            <StyledDateInfo
-              $selected={equalDates(date, selectedDate)}
-              onClick={() => selectDate(date)}
-              disabled={!showDates.includes(dateNumber)}
-            >
-              <StyledDay>{equalDates(date, today) ? '오늘' : day}</StyledDay>
-              <StyledDate>{dateNumber}</StyledDate>
-            </StyledDateInfo>
-          </li>
-        );
-      })}
+          return (
+            <li key={dateNumber}>
+              <StyledDateInfo
+                $selected={equalDates(date, selectedDate)}
+                onClick={() => selectDate(date)}
+                disabled={!showDates.includes(dateNumber)}
+              >
+                <StyledDay>{equalDates(date, today) ? '오늘' : day}</StyledDay>
+                <StyledDate>{dateNumber}</StyledDate>
+              </StyledDateInfo>
+            </li>
+          );
+        })}
+      </StyledDateContainer>
     </StyledDateGroup>
   );
 };
 
-const StyledDateGroup = styled.ul`
-  width: 100%;
+const StyledDateGroup = styled.div`
+  flex: 1;
+  overflow: hidden;
+`;
+
+const StyledDateContainer = styled.ul`
   display: flex;
-  justify-content: space-around;
+  transition: transform 0.3s ease-in-out;
 `;
 
 const StyledDateInfo = styled.button<{ $selected: boolean }>`
   display: flex;
   flex-direction: column;
   align-items: center;
-  min-width: 24px;
+  width: 92px;
 
   &:hover {
     cursor: pointer;

--- a/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
@@ -23,8 +23,6 @@ export const DateController: React.FC<Props> = ({
     setShowsAtDate: state.setShowsAtDate,
   }));
 
-  const currentDateGroup = getCurrentDateGroup(datesInMonth, centerDateIndex);
-
   const goToPreviousGroup = () =>
     setCenterDateIndex((p) => getCenterDateIndex(p - 9));
   const goToNextGroup = () =>
@@ -76,7 +74,8 @@ export const DateController: React.FC<Props> = ({
         <CaretLeft onClick={goToPreviousGroup} />
       </StyledArrowButton>
       <DateGroup
-        dates={currentDateGroup}
+        dates={datesInMonth}
+        centerDateIndex={centerDateIndex}
         showDates={showDates}
         selectedDate={selectedDate}
         selectDate={selectDate}
@@ -86,18 +85,6 @@ export const DateController: React.FC<Props> = ({
       </StyledArrowButton>
     </StyledDateContainer>
   );
-};
-
-const getCurrentDateGroup = (datesInMonth: Date[], dateIndex: number) => {
-  if (dateIndex < 7) {
-    return datesInMonth.slice(0, 13);
-  }
-
-  if (datesInMonth.length - dateIndex < 7) {
-    return datesInMonth.slice(datesInMonth.length - 13, datesInMonth.length);
-  }
-
-  return datesInMonth.slice(dateIndex - 6, dateIndex + 7);
 };
 
 const getCenterDateIndex = (index: number) => {
@@ -180,6 +167,19 @@ const StyledArrowButton = styled.button`
 
     &:active {
       opacity: 0.5;
+    }
+  }
+
+  @media screen and (max-width: 1264px) {
+    position: static;
+
+    &:first-of-type {
+      transform: none;
+    }
+
+    &:last-of-type {
+      right: 0;
+      transform: none;
     }
   }
 `;

--- a/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
@@ -112,7 +112,7 @@ const getCenterDateIndex = (index: number, lastIndex?: number) => {
   }
 
   if (lastIndex && index > lastIndex) {
-    return index;
+    return lastIndex;
   }
 
   return index;

--- a/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
+++ b/fe/user/src/pages/ShowPage/CalendarDate/DateController/index.tsx
@@ -25,12 +25,16 @@ export const DateController: React.FC<Props> = ({
   }));
   const dateGroupRef = useRef<HTMLDivElement>(null);
 
+  const datePerWidth =
+    dateGroupRef.current === null
+      ? 1
+      : dateGroupRef.current.offsetWidth / DATE_BUTTON_WIDTH;
+
   const goToPreviousGroup = () => {
     if (!dateGroupRef.current) {
       return;
     }
 
-    const datePerWidth = dateGroupRef.current.offsetWidth / DATE_BUTTON_WIDTH;
     setCenterDateIndex((p) => getCenterDateIndex(p - datePerWidth));
   };
   const goToNextGroup = () => {
@@ -38,10 +42,8 @@ export const DateController: React.FC<Props> = ({
       return;
     }
 
-    const datePerWidth = dateGroupRef.current.offsetWidth / DATE_BUTTON_WIDTH;
-    const lastDateIndexOfMonth = datesInMonth.length - 1;
     setCenterDateIndex((p) =>
-      getCenterDateIndex(p + datePerWidth, lastDateIndexOfMonth),
+      getCenterDateIndex(p + datePerWidth, datesInMonth.length - 1),
     );
   };
   useEffect(() => {


### PR DESCRIPTION
## What is this PR? 👓
공연 페이지에 날짜를 표시하는 방식을 변경한다.

기존에는 13개씩 날짜를 뽑아서 렌더링하는 방식을 적용했다.
이 방식은 브라우저 크기가 작을 때 13개의 숫자가 좁은 너비에 다 들어가다보니 시인성과 사용성에 큰 해를 준다.

선택한 연월에 해당하는 날짜(30일 또는 31일)를 모두 렌더링하고 너비를 넘는 날짜는 잘리도록 변경하는 방식으로 이를 변경한다.

브라우저 너비가 작아지면 화살표로 이동하는 날짜 개수를 줄인다.

## Key changes 🔑
- DateGroup : dateGroup의 center index인 날짜를 화면의 가운데 위치시키는 로직 추가
- DateController : dateGroupRef로 화면에 보이는 날짜 개수를 계산해서 centerIndex를 계산하도록 했습니다.

## To reviewers 👋
