### PR TITLE
Be/fix/#189 공연장 목록 조회 검색, 지도기반 에서 null 이 반환되는 문제

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/image/entity/Image.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/entity/Image.java
@@ -18,7 +18,7 @@ public class Image extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-	@Column(nullable = false, unique = true, length = 500)
+	@Column(nullable = false, length = 500)
 	private String url;
 	@Enumerated(value = EnumType.STRING)
 	@Column(nullable = false, length = 12)

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/mapper/VenueMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/mapper/VenueMapper.java
@@ -45,13 +45,22 @@ public interface VenueMapper {
 	@Mapping(target = "longitude", source = "location.x")
 	VenuePinsResponse toVenuePinsBySearchResponse(VenuePins venuePinsByWord);
 
-	@Mapping(target = "venues", source = "venueSearchList.content")
+	default VenueSearchResponse toVenueSearchResponse(Page<VenueSearchData> venueSearchList, int currentPage) {
+		List<VenueSearchData> content = venueSearchList.getContent();
+		if (!venueSearchList.hasContent()) {
+			content = new ArrayList<>();
+		}
+		return toVenueSearchResponse(content, venueSearchList, currentPage);
+	}
+
 	@Mapping(target = "totalCount", source = "venueSearchList.totalElements")
 	@Mapping(target = "maxPage", source = "venueSearchList.totalPages")
-	VenueSearchResponse toVenueSearchResponse(Page<VenueSearchData> venueSearchList, int currentPage);
+	VenueSearchResponse toVenueSearchResponse(List<VenueSearchData> venues, Page<VenueSearchData> venueSearchList,
+		int currentPage);
 
 	@Mapping(target = "venues", source = "venueSearchList")
-	VenueSearchResponse toVenueSearchResponse(List<VenueSearchData> venueSearchList, int totalCount, int currentPage, int maxPage);
+	VenueSearchResponse toVenueSearchResponse(List<VenueSearchData> venueSearchList, int totalCount, int currentPage,
+		int maxPage);
 
 	default VenueSearch toVenueSearch(VenueSearchData venueSearchData) {
 		List<ShowInfo> showInfo = venueSearchData.getShowInfo();


### PR DESCRIPTION
## What is this PR? 👓
- https://github.com/jazz-meet/jazz-meet/issues/189

## Key changes 🔑
- 공연장 목록 조회 - 검색, 지도 기반에 나타나던 문제를 수정했습니다. (null 반환 -> [] 빈 배열 반환)
- 또 image에 걸어놓은 url unique 설정을 제거했습니다.

## To reviewers 👋
