### PR TITLE
이미지 업로드 response에 url 추가

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/image/controller/ImageController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/controller/ImageController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import kr.codesquad.jazzmeet.image.dto.response.ImageIdsResponse;
+import kr.codesquad.jazzmeet.image.dto.response.ImageCreateResponse;
 import kr.codesquad.jazzmeet.image.service.CloudService;
 import kr.codesquad.jazzmeet.image.service.ImageService;
 import lombok.RequiredArgsConstructor;
@@ -27,11 +27,11 @@ public class ImageController {
 	 * 이미지 업로드 API
 	 */
 	@PostMapping("/api/images")
-	public ResponseEntity<ImageIdsResponse> uploadImages(@RequestPart("image") List<MultipartFile> multipartFiles) {
+	public ResponseEntity<ImageCreateResponse> uploadImages(@RequestPart("image") List<MultipartFile> multipartFiles) {
 		List<String> imageUrls = cloudService.uploadImages(multipartFiles);
-		ImageIdsResponse imageIdsResponse = imageService.saveImages(imageUrls);
+		ImageCreateResponse imageCreateResponse = imageService.saveImages(imageUrls);
 
-		return ResponseEntity.status(HttpStatus.CREATED).body(imageIdsResponse);
+		return ResponseEntity.status(HttpStatus.CREATED).body(imageCreateResponse);
 	}
 
 	/**

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/dto/response/ImageCreateResponse.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/dto/response/ImageCreateResponse.java
@@ -2,7 +2,7 @@ package kr.codesquad.jazzmeet.image.dto.response;
 
 import java.util.List;
 
-public record ImageIdsResponse (
-	List<Long> ids
+public record ImageCreateResponse(
+	List<ImageSaveResponse> images
 ) {
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/dto/response/ImageSaveResponse.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/dto/response/ImageSaveResponse.java
@@ -1,0 +1,7 @@
+package kr.codesquad.jazzmeet.image.dto.response;
+
+public record ImageSaveResponse(
+	Long id,
+	String url
+) {
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/entity/Image.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/entity/Image.java
@@ -10,14 +10,17 @@ import jakarta.persistence.Id;
 import kr.codesquad.jazzmeet.global.time.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Image extends BaseTimeEntity {
+	@Getter
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+	@Getter
 	@Column(nullable = false, length = 500)
 	private String url;
 	@Enumerated(value = EnumType.STRING)
@@ -28,14 +31,6 @@ public class Image extends BaseTimeEntity {
 	public Image(String url, ImageStatus status) {
 		this.url = url;
 		this.status = status;
-	}
-
-	public Long getId() {
-		return id;
-	}
-
-	public String getUrl() {
-		return url;
 	}
 
 	public void delete() {

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/mapper/ImageMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/mapper/ImageMapper.java
@@ -3,6 +3,7 @@ package kr.codesquad.jazzmeet.image.mapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
+import kr.codesquad.jazzmeet.image.dto.response.ImageSaveResponse;
 import kr.codesquad.jazzmeet.image.entity.Image;
 import kr.codesquad.jazzmeet.image.entity.ImageStatus;
 
@@ -12,4 +13,6 @@ public interface ImageMapper {
 	ImageMapper INSTANCE = Mappers.getMapper(ImageMapper.class);
 
 	Image toImage(String url, ImageStatus status);
+
+	ImageSaveResponse toImageSaveResponse(Image saveImage);
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
@@ -8,7 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import kr.codesquad.jazzmeet.global.error.CustomException;
 import kr.codesquad.jazzmeet.global.error.statuscode.ImageErrorCode;
-import kr.codesquad.jazzmeet.image.dto.response.ImageIdsResponse;
+import kr.codesquad.jazzmeet.image.dto.response.ImageCreateResponse;
+import kr.codesquad.jazzmeet.image.dto.response.ImageSaveResponse;
 import kr.codesquad.jazzmeet.image.entity.Image;
 import kr.codesquad.jazzmeet.image.entity.ImageStatus;
 import kr.codesquad.jazzmeet.image.mapper.ImageMapper;
@@ -25,17 +26,17 @@ public class ImageService {
 	private final ImageQueryRepository imageQueryRepository;
 
 	@Transactional
-	public ImageIdsResponse saveImages(List<String> imageUrls) {
+	public ImageCreateResponse saveImages(List<String> imageUrls) {
 		List<Image> images = imageUrls.stream()
 			.map(url -> ImageMapper.INSTANCE.toImage(url, ImageStatus.UNREGISTERED))
 			.toList();
 
 		List<Image> saveImages = imageRepository.saveAll(images);
-		List<Long> ids = saveImages.stream()
-			.map(Image::getId)
+		List<ImageSaveResponse> imageSaveResponses = saveImages.stream()
+			.map(ImageMapper.INSTANCE::toImageSaveResponse)
 			.toList();
 
-		return new ImageIdsResponse(ids);
+		return new ImageCreateResponse(imageSaveResponses);
 	}
 
 	@Transactional

--- a/be/src/test/java/kr/codesquad/jazzmeet/image/repository/ImageRepositoryTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/image/repository/ImageRepositoryTest.java
@@ -32,7 +32,7 @@ class ImageRepositoryTest extends IntegrationTestSupport {
 	@Test
 	@DisplayName("이미지의 상태가 DELETED 이거나 상태가 UNREGISTERED 이면서 생성일자가 오늘이 아닌 이미지를 모두 조회한다")
 	void findAllStatusNotRegistered() {
-	    // given
+		// given
 		Image image1 = ImageFixture.createImage("url1", ImageStatus.REGISTERED);
 		Image image2 = ImageFixture.createImage("url2", ImageStatus.UNREGISTERED);
 		Image image3 = ImageFixture.createImage("url3", ImageStatus.DELETED);
@@ -40,7 +40,7 @@ class ImageRepositoryTest extends IntegrationTestSupport {
 		imageRepository.saveAll(List.of(image1, image2, image3));
 
 		LocalDate today = LocalDate.now();
-		LocalDate yesterday = LocalDate.of(today.getYear(), today.getMonth(), today.getDayOfMonth() - 1);
+		LocalDate yesterday = today.minusDays(1);
 
 		// when
 		List<Image> images = imageQueryRepository.findAllNotRegistered(yesterday);
@@ -54,7 +54,7 @@ class ImageRepositoryTest extends IntegrationTestSupport {
 	@DisplayName("URL의 리스트를 입력 받아서 URL에 해당하는 이미지를 모두 삭제한다")
 	@Transactional
 	void deleteImagesByUrls() {
-	    // given
+		// given
 		Image image1 = ImageFixture.createImage("url1");
 		Image image2 = ImageFixture.createImage("url2");
 		Image image3 = ImageFixture.createImage("url3");
@@ -65,7 +65,7 @@ class ImageRepositoryTest extends IntegrationTestSupport {
 		// when
 		imageQueryRepository.deleteAllInUrls(imageUrls);
 
-	    // then
+		// then
 		List<Image> images = imageRepository.findAll();
 		assertThat(images).extracting("url")
 			.containsExactly("url3");

--- a/be/src/test/java/kr/codesquad/jazzmeet/image/service/ImageServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/image/service/ImageServiceTest.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import kr.codesquad.jazzmeet.IntegrationTestSupport;
 import kr.codesquad.jazzmeet.fixture.ImageFixture;
 import kr.codesquad.jazzmeet.global.error.CustomException;
-import kr.codesquad.jazzmeet.image.dto.response.ImageIdsResponse;
+import kr.codesquad.jazzmeet.image.dto.response.ImageCreateResponse;
 import kr.codesquad.jazzmeet.image.entity.Image;
 import kr.codesquad.jazzmeet.image.entity.ImageStatus;
 import kr.codesquad.jazzmeet.image.repository.ImageRepository;
@@ -33,27 +33,27 @@ class ImageServiceTest extends IntegrationTestSupport {
 	@Test
 	@DisplayName("이미지 URL의 리스트를 받아서 저장하고 이미지 ID의 리스트를 반환한다")
 	void saveImages() {
-	    // given
+		// given
 		List<String> imageUrls = List.of("imgUrl1", "imgUrl2", "imgUrl3");
 
 		// when
-		ImageIdsResponse imageIdsResponse = imageService.saveImages(imageUrls);
+		ImageCreateResponse imageCreateResponse = imageService.saveImages(imageUrls);
 
 		// then
-		assertThat(imageIdsResponse.ids()).hasSize(imageUrls.size());
+		assertThat(imageCreateResponse.images()).hasSize(imageUrls.size());
 	}
 
 	@Test
 	@DisplayName("이미지의 상태를 삭제 상태로 변경한다")
 	void deleteImage() {
-	    // given
+		// given
 		Image image = ImageFixture.createImage("imgUrl");
 		Image savedImage = imageRepository.save(image);
 
 		// when
 		imageService.deleteImage(savedImage.getId());
 
-	    // then
+		// then
 		Image deletedImage = imageRepository.findById(savedImage.getId()).get();
 		assertThat(deletedImage).extracting("status").isEqualTo(ImageStatus.DELETED);
 	}


### PR DESCRIPTION
## What is this PR? 👓
- https://github.com/jazz-meet/jazz-meet/issues/204

## Key changes 🔑
### 기존
```json
{
  "ids": [1, 2, 3]
}
```

### 변경 후
```json
{
    "images": [
        {
            "id": 1,
            "url": "https://"
        },
        {
            "id": 2,
            "url": "https://"
        }
    ]
}
```

## To reviewers 👋
- Mapstruct로 해결하려고 했는데 메서드 파라미터로 List 를 설정했을 때, 오류가 생기던데 혹시 해결방법을 아시나요?
    - 오류: can't generate mapping method from iterable type from java stdlib to non-iterable type.
    - 예제: 
```java
@Mapping(target = "images", source = "images")
ImageCreateResponse toImageCreateResponse(List<ImageSaveResponse> images);
```

```java
public record ImageCreateResponse(
	List<ImageSaveResponse> images
) {
}
```

