### PR TITLE
공연장 목록 QA 피드백 반영

### DIFF
--- a/fe/user/src/pages/MapPage/Panel/VenueList/VenueItem/Description.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueList/VenueItem/Description.tsx
@@ -22,14 +22,18 @@ export const Description: React.FC<Props> = ({
       <StyledMainContent>
         <StyledIntroduction>{description}</StyledIntroduction>
         <StyledSchedule>
-          {showInfo.map(({ startTime, endTime }, index) => (
-            <StyledShowTime key={index}>
-              <span>{index + 1}부</span>
-              <span>
-                {isoToTimeFormat(startTime)}~{isoToTimeFormat(endTime)}
-              </span>
-            </StyledShowTime>
-          ))}
+          {showInfo.length > 0 ? (
+            showInfo.map(({ startTime, endTime }, index) => (
+              <StyledShowTime key={index}>
+                <span>{index + 1}부</span>
+                <span>
+                  {isoToTimeFormat(startTime)}~{isoToTimeFormat(endTime)}
+                </span>
+              </StyledShowTime>
+            ))
+          ) : (
+            <StyledShowTime>공연없음</StyledShowTime>
+          )}
         </StyledSchedule>
       </StyledMainContent>
     </StyledDescription>

--- a/fe/user/src/pages/MapPage/Panel/VenueList/VenueItem/Description.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueList/VenueItem/Description.tsx
@@ -40,7 +40,7 @@ const StyledDescription = styled.article`
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 75px;
+  gap: 32px;
 `;
 
 const StyledHeader = styled.header`
@@ -56,7 +56,7 @@ const StyledName = styled.h3`
 `;
 
 const StyledAddress = styled.span`
-  font-size: 20px;
+  font-size: 18px;
   font-weight: 500;
   color: #848484;
 `;

--- a/fe/user/src/pages/MapPage/Panel/VenueList/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueList/index.tsx
@@ -16,9 +16,9 @@ export const VenueList: React.FC<Props> = ({
   handleChangeVenueListPage,
 }) => {
   const { search } = useLocation();
-  const scrollTargetRef = useRef<HTMLDivElement>(null);
+  const venueListRef = useRef<HTMLDivElement>(null);
 
-  const scrollToTop = () => scrollTargetRef.current?.scrollIntoView();
+  const scrollToTop = () => venueListRef.current?.scrollTo({ top: 0 });
 
   const onVenueListPageChange = (
     _: React.ChangeEvent<unknown>,
@@ -29,8 +29,7 @@ export const VenueList: React.FC<Props> = ({
   };
 
   return (
-    <StyledVenueList>
-      <StyledScrollTarget ref={scrollTargetRef} />
+    <StyledVenueList ref={venueListRef}>
       <StyledTotalCount>
         <h2>전체</h2>
         <span>{searchedVenus?.totalCount ?? 0}</span>
@@ -82,11 +81,6 @@ const StyledVenueList = styled.div`
   &::-webkit-scrollbar-track {
     background-color: transparent;
   }
-`;
-
-const StyledScrollTarget = styled.div`
-  position: absolute;
-  top: 0;
 `;
 
 const StyledTotalCount = styled.div`

--- a/fe/user/src/pages/MapPage/Panel/VenueList/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueList/index.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import { useRef } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { PaginationBox } from '~/components/PaginationBox';
 import { SearchedVenues } from '~/types/api.types';
@@ -15,16 +16,21 @@ export const VenueList: React.FC<Props> = ({
   handleChangeVenueListPage,
 }) => {
   const { search } = useLocation();
+  const scrollTargetRef = useRef<HTMLDivElement>(null);
+
+  const scrollToTop = () => scrollTargetRef.current?.scrollIntoView();
 
   const onVenueListPageChange = (
     _: React.ChangeEvent<unknown>,
     value: number,
   ) => {
     handleChangeVenueListPage(value);
+    scrollToTop();
   };
 
   return (
     <StyledVenueList>
+      <StyledScrollTarget ref={scrollTargetRef} />
       <StyledTotalCount>
         <h2>전체</h2>
         <span>{searchedVenus?.totalCount ?? 0}</span>
@@ -56,6 +62,7 @@ export const VenueList: React.FC<Props> = ({
 };
 
 const StyledVenueList = styled.div`
+  position: relative;
   width: 100%;
   background-color: #fff;
   padding: 20px;
@@ -75,6 +82,11 @@ const StyledVenueList = styled.div`
   &::-webkit-scrollbar-track {
     background-color: transparent;
   }
+`;
+
+const StyledScrollTarget = styled.div`
+  position: absolute;
+  top: 0;
 `;
 
 const StyledTotalCount = styled.div`


### PR DESCRIPTION
## What is this PR? 👓
공연장 목록 QA 피드백 반영
- 공연장 주소와 상세정보 사이의 간격 줄이기
- 페이지 이동 시 목록 상단으로 이동
- 당일 공연 없는 공연장에 공연 없음 표시

## Key changes 🔑
VenueList - onVenueListPageChange
- scrollToTop() 메서드를 추가적으로 호출

## To reviewers 👋
전체 페이지에 적용된 스크롤이 아니라 DOM 직접 조작을 할까 하다가 리액트 공식문서에서 찾은 scrollIntoView()로 구현을 해봤습니다.
공연장 목록 컴포넌트에 적용된 padding 때문에 position: absolute, top:0인 StyleScrollTarget을 만들었습니다.

추가로 behavior: smooth는 약간 어지러운 느낌도 있어서 일부러 적용하지 않았습니다.
