### PR TITLE
문의 글 목록 조회 시 status 필터 추가

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/controller/InquiryController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/controller/InquiryController.java
@@ -38,8 +38,9 @@ public class InquiryController {
 	public ResponseEntity<InquirySearchResponse> getInquiries(
 		@RequestParam(defaultValue = "서비스") String category,
 		@RequestParam(required = false) String word,
+		@RequestParam(required = false) String status,
 		@RequestParam(defaultValue = "1") @Min(value = 1) int page) {
-		InquirySearchResponse inquiries = inquiryService.getInquiries(category, word, page);
+		InquirySearchResponse inquiries = inquiryService.getInquiries(category, word, status, page);
 
 		return ResponseEntity.ok(inquiries);
 	}

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/repository/InquiryQueryRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/repository/InquiryQueryRepository.java
@@ -29,7 +29,8 @@ public class InquiryQueryRepository {
 
 	private final JPAQueryFactory query;
 
-	public Page<InquirySearchData> searchInquiries(String word, InquiryCategory category, Pageable pageable) {
+	public Page<InquirySearchData> searchInquiries(InquiryCategory category, String word, InquiryStatus status,
+		Pageable pageable) {
 		List<InquirySearchData> inquiries = query.select(
 				Projections.fields(InquirySearchData.class,
 					inquiry.id,
@@ -41,6 +42,7 @@ public class InquiryQueryRepository {
 			.from(inquiry)
 			.where(isContainNickNameOrContent(word)
 				.and(isEqualsCategory(category))
+				.and(isEqualsStatus(status))
 				.and(isNotDeleted()))
 			.limit(pageable.getPageSize())
 			.offset(pageable.getOffset())
@@ -88,6 +90,13 @@ public class InquiryQueryRepository {
 			return null;
 		}
 		return inquiry.category.eq(category);
+	}
+
+	private BooleanExpression isEqualsStatus(InquiryStatus status) {
+		if (status == null || status.equals("")) {
+			return null;
+		}
+		return inquiry.status.eq(status);
 	}
 
 	public Optional<InquiryDetail> findInquiryAndAnswerByInquiryId(Long inquiryId) {

--- a/be/src/main/java/kr/codesquad/jazzmeet/inquiry/service/InquiryService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/inquiry/service/InquiryService.java
@@ -45,13 +45,17 @@ public class InquiryService {
 	private final InquiryAnswerRepository answerRepository;
 	private final InquiryRepository inquiryRepository;
 
-	public InquirySearchResponse getInquiries(String category, String word, int page) {
+	public InquirySearchResponse getInquiries(String category, String word, String status, int page) {
 		// request는 한글, DB 저장은 영어로 되어있기 때문에 변환 필요.
 		InquiryCategory inquiryCategory = InquiryCategory.toInquiryCategory(category);
+		InquiryStatus inquiryStatus = null;
+		if (status != null) {
+			inquiryStatus = InquiryStatus.toInquiryStatus(status);
+		}
 		PageRequest pageRequest = PageRequest.of(page - PAGE_NUMBER_OFFSET, PAGE_SIZE);
 
-		Page<InquirySearchData> inquirySearchData = inquiryQueryRepository.searchInquiries(word, inquiryCategory,
-			pageRequest);
+		Page<InquirySearchData> inquirySearchData = inquiryQueryRepository.searchInquiries(inquiryCategory,
+			word, inquiryStatus, pageRequest);
 		List<InquirySearch> inquirySearches = inquirySearchData.getContent()
 			.stream()
 			.map(InquiryMapper.INSTANCE::toInquirySearch).toList();

--- a/be/src/test/java/kr/codesquad/jazzmeet/inquiry/service/InquiryServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/inquiry/service/InquiryServiceTest.java
@@ -66,10 +66,11 @@ class InquiryServiceTest extends IntegrationTestSupport {
 
 		// when
 		String category = InquiryCategory.SERVICE.getKoName();
+		String status = InquiryStatus.WAITING.getKoName();
 		String word = null;
 		int page = 1;
 
-		InquirySearchResponse inquirySearchResponse = inquiryService.getInquiries(category, word, page);
+		InquirySearchResponse inquirySearchResponse = inquiryService.getInquiries(category, word, status, page);
 
 		// then
 		assertThat(inquirySearchResponse.inquiries()).hasSize(2);
@@ -89,10 +90,11 @@ class InquiryServiceTest extends IntegrationTestSupport {
 
 		// when
 		String category = InquiryCategory.SERVICE.getKoName();
+		String status = InquiryStatus.WAITING.getKoName();
 		String word = "수정";
 		int page = 1;
 
-		InquirySearchResponse inquirySearchResponse = inquiryService.getInquiries(category, word, page);
+		InquirySearchResponse inquirySearchResponse = inquiryService.getInquiries(category, word, status, page);
 		// then
 		assertThat(inquirySearchResponse.inquiries())
 			.hasSize(2)
@@ -118,10 +120,11 @@ class InquiryServiceTest extends IntegrationTestSupport {
 
 		// when
 		String category = InquiryCategory.SERVICE.getKoName();
+		String status = InquiryStatus.WAITING.getKoName();
 		String word = "지안";
 		int page = 1;
 
-		InquirySearchResponse inquirySearchResponse = inquiryService.getInquiries(category, word, page);
+		InquirySearchResponse inquirySearchResponse = inquiryService.getInquiries(category, word, status, page);
 		// then
 		assertThat(inquirySearchResponse.inquiries())
 			.hasSize(2)
@@ -130,6 +133,33 @@ class InquiryServiceTest extends IntegrationTestSupport {
 			.doesNotContain(inquiry3.getNickname())
 			.contains(inquiry1.getNickname())
 			.contains(inquiry4.getNickname());
+	}
+
+	@Test
+	@DisplayName("문의 상태에 해당되는 문의 목록을 조회한다.")
+	void searchInquiriesByStatus() {
+		// given
+		Inquiry inquiry1 = InquiryFixture.createInquiry(InquiryCategory.SERVICE);
+		Inquiry inquiry2 = InquiryFixture.createInquiry(InquiryCategory.SERVICE);
+
+		inquiryRepository.save(inquiry1);
+		inquiryRepository.save(inquiry2);
+		InquiryAnswerSaveRequest request = InquiryFixture.createInquiryAnswerSaveRequest(inquiry1.getId());
+		inquiryService.saveAnswer(request);
+
+		// when
+		String category = InquiryCategory.SERVICE.getKoName();
+		String status = InquiryStatus.WAITING.getKoName();
+		String word = null;
+		int page = 1;
+
+		InquirySearchResponse inquirySearchResponse = inquiryService.getInquiries(category, word, status, page);
+		// then
+		assertThat(inquirySearchResponse.inquiries())
+			.hasSize(1)
+			.extracting(InquirySearch::id)
+			.doesNotContain(inquiry1.getId())
+			.contains(inquiry2.getId());
 	}
 
 	@Test


### PR DESCRIPTION
## What is this PR? 👓
- https://github.com/jazz-meet/jazz-meet/issues/223

## Key changes 🔑
- 관리자 페이지에서 "검토중"인 문의만 볼 수 있도록 status 필터 기능 추가

## To reviewers 👋
- 브랜치 네이밍 및 커밋 컨벤션을 고민했습니다.
    - 수정이긴 하니까 fix로 할까 고민하다가 status로 검색하는 기능을 추가하는 거니까 feat으로 결정했습니다.