### PR TITLE
공연장 수정 시 이미지가 반환되지 않는 오류 수정

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
@@ -50,6 +50,11 @@ public class ImageService {
 			.orElseThrow(() -> new CustomException(ImageErrorCode.NOT_FOUND_IMAGE));
 	}
 
+	public Image findByIdExistDeleted(Long imageId) {
+		return imageRepository.findById(imageId)
+			.orElseThrow(() -> new CustomException(ImageErrorCode.NOT_FOUND_IMAGE));
+	}
+
 	public List<String> findNotRegisteredImageUrls() {
 		LocalDate today = LocalDate.now();
 		// UNREGISTERED 상태는 created_at이 today와 다른 데이터 조회

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueFacade.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueFacade.java
@@ -107,7 +107,7 @@ public class VenueFacade {
 	private void addVenueImages(Venue venue, List<Long> imageIds) {
 		AtomicLong imageOrder = new AtomicLong();
 		imageIds.forEach(imageId -> {
-			Image image = imageService.findById(imageId);
+			Image image = imageService.findByIdExistDeleted(imageId);
 			image.register();
 			VenueImage venueImage = VenueImage.builder()
 				.imageOrder(imageOrder.incrementAndGet())


### PR DESCRIPTION
## What is this PR? 👓
- https://github.com/jazz-meet/jazz-meet/issues/229

## Key changes 🔑
- imageService에 findByIdExistDeleted(imageId)를 추가해서 문제를 해결했습니다.

## To reviewers 👋
- 기존 공연장 이미지 삭제 시에 deleted로 변경되어 imageService.findById(imageId) 시 오류가 발생하는 것 같았습니다.
- 적절한 해결 방법은 아닌 것 같지만 임시 조치 했습니다.
