### PR TITLE
fix: 공연 등록 시 description 저장 안되는 문제 해결

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/show/entity/Show.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/entity/Show.java
@@ -44,8 +44,10 @@ public class Show {
 	private Long adminId;
 
 	@Builder
-	public Show(String teamName, LocalDateTime startTime, LocalDateTime endTime, Venue venue, Image poster) {
+	public Show(String teamName, String description, LocalDateTime startTime, LocalDateTime endTime, Venue venue,
+		Image poster) {
 		this.teamName = teamName;
+		this.description = description;
 		this.startTime = startTime;
 		this.endTime = endTime;
 		this.venue = venue;

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
@@ -37,5 +37,6 @@ public interface ShowMapper {
 	@Mapping(target = "venueName", source = "venue.name")
 	ShowDetailResponse toShowDetailResponse(Show show);
 
+	@Mapping(target = "description", source = "registerShowRequest.description")
 	Show toShow(RegisterShowRequest registerShowRequest, Venue venue, Image poster);
 }


### PR DESCRIPTION
## What is this PR? 👓
공연 등록 시 description 저장 안되는 문제 해결했습니다.

## To reviewers 👋
테스트코드에서 저장된 id만 확인하고 넘어갔더니 이런 대참사가 일어났군요,,, venue과 request에서 동일한 이름의 description 속성이 있어서 mapstruct가 찾지 못해 null이 들어갔습니다. reqeust의 description으로 지정해서 해결했습니다.