### PR TITLE
문의 페이지 모바일 UI 적용

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/show/dto/response/UpcomingShowResponse.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/dto/response/UpcomingShowResponse.java
@@ -6,7 +6,7 @@ public record UpcomingShowResponse(
 	Long venueId,
 	Long showId,
 	String posterUrl,
-	String showName,
+	String teamName,
 	LocalDateTime startTime,
 	LocalDateTime endTime) {
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
@@ -22,7 +22,6 @@ public interface ShowMapper {
 	@Mapping(target = "venueId", source = "venue.id")
 	@Mapping(target = "showId", source = "id")
 	@Mapping(target = "posterUrl", source = "poster.url")
-	@Mapping(target = "showName", source = "teamName")
 	UpcomingShowResponse toUpcomingShowResponse(Show show);
 
 	@Mapping(target = "posterUrl", source = "poster.url")

--- a/fe/user/src/pages/InquiryPage/Editor/index.tsx
+++ b/fe/user/src/pages/InquiryPage/Editor/index.tsx
@@ -17,7 +17,7 @@ type Props = {
 };
 
 export const InquiryEditor: React.FC<Props> = ({ currentCategory }) => {
-  const { isMobile } = useDeviceTypeStore().deviceType;
+  const { isMobile } = useDeviceTypeStore((state) => state.deviceType);
 
   const [inquiryContent, setInquiryContent] = useState('');
 

--- a/fe/user/src/pages/InquiryPage/Editor/index.tsx
+++ b/fe/user/src/pages/InquiryPage/Editor/index.tsx
@@ -8,6 +8,7 @@ import {
   INQUIRY_PASSWORD_MAX_LENGTH,
   INQUIRY_PASSWORD_MIN_LENGTH,
 } from '~/constants/LIMITS';
+import { useDeviceTypeStore } from '~/stores/useDeviceTypeStore';
 import { InquiryCategories } from '~/types/inquiry.types';
 import { validateInputLength } from '~/utils/validation';
 
@@ -16,6 +17,8 @@ type Props = {
 };
 
 export const InquiryEditor: React.FC<Props> = ({ currentCategory }) => {
+  const { isMobile } = useDeviceTypeStore().deviceType;
+
   const [inquiryContent, setInquiryContent] = useState('');
 
   const onChangeInquiryContent = (value: string) => {
@@ -72,13 +75,8 @@ export const InquiryEditor: React.FC<Props> = ({ currentCategory }) => {
 
   return (
     <StyledInquiryEditor onSubmit={onInquirySubmit}>
-      <StyledInquiryInputSection>
-        <AutoSizingTextArea
-          required
-          value={inquiryContent}
-          onChange={onChangeInquiryContent}
-        />
-        <StyledUserInfoInput>
+      <StyledInquiryInputSection $isMobile={isMobile}>
+        <StyledUserInfoInput $isMobile={isMobile}>
           <input
             name={NICKNAME}
             required
@@ -96,6 +94,11 @@ export const InquiryEditor: React.FC<Props> = ({ currentCategory }) => {
             placeholder="비밀번호"
           />
         </StyledUserInfoInput>
+        <AutoSizingTextArea
+          required
+          value={inquiryContent}
+          onChange={onChangeInquiryContent}
+        />
       </StyledInquiryInputSection>
       <StyledSubmit>등록하기</StyledSubmit>
     </StyledInquiryEditor>
@@ -113,9 +116,10 @@ const StyledInquiryEditor = styled.form`
   gap: 21px;
 `;
 
-const StyledInquiryInputSection = styled.div`
+const StyledInquiryInputSection = styled.div<{ $isMobile: boolean }>`
   width: 100%;
   display: flex;
+  ${({ $isMobile }) => $isMobile && 'flex-direction: column;'}
   gap: 8px;
 
   & textarea,
@@ -142,13 +146,13 @@ const StyledInquiryInputSection = styled.div`
   }
 `;
 
-const StyledUserInfoInput = styled.div`
+const StyledUserInfoInput = styled.div<{ $isMobile: boolean }>`
   display: flex;
-  flex-direction: column;
+  ${({ $isMobile }) => !$isMobile && `flex-direction: column;`}
   gap: 8px;
 
   & input {
-    width: 180px;
+    width: ${({ $isMobile }) => ($isMobile ? `50%` : '180px')};
     height: 44px;
     padding: 8px 24px;
     border-radius: 2px;

--- a/fe/user/src/pages/InquiryPage/Editor/index.tsx
+++ b/fe/user/src/pages/InquiryPage/Editor/index.tsx
@@ -140,8 +140,8 @@ const StyledInquiryInputSection = styled.div<{ $isMobile: boolean }>`
 
   & textarea {
     flex: 1;
-    min-height: 96px;
-    padding: 16px 24px;
+    min-height: ${({ $isMobile }) => ($isMobile ? '64px' : '80px')};
+    padding: ${({ $isMobile }) => ($isMobile ? '8px 12px' : '16px 24px')};
     resize: none;
   }
 `;
@@ -153,8 +153,8 @@ const StyledUserInfoInput = styled.div<{ $isMobile: boolean }>`
 
   & input {
     width: ${({ $isMobile }) => ($isMobile ? `50%` : '180px')};
-    height: 44px;
-    padding: 8px 24px;
+    height: ${({ $isMobile }) => ($isMobile ? `36px` : '44px')};
+    padding: ${({ $isMobile }) => ($isMobile ? `8px 12px;` : '8px 24px;')};
     border-radius: 2px;
 
     &::placeholder {

--- a/fe/user/src/pages/InquiryPage/Header/index.tsx
+++ b/fe/user/src/pages/InquiryPage/Header/index.tsx
@@ -16,7 +16,7 @@ export const Header: React.FC<Props> = ({
   onWordChange,
   onSearchClear,
 }) => {
-  const { isMobile } = useDeviceTypeStore().deviceType;
+  const { isMobile } = useDeviceTypeStore((state) => state.deviceType);
   const onSearchSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 

--- a/fe/user/src/pages/InquiryPage/Header/index.tsx
+++ b/fe/user/src/pages/InquiryPage/Header/index.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import ClearIcon from '@mui/icons-material/Clear';
 import SearchIcon from '@mui/icons-material/Search';
 import { IconButton, InputBase, Paper, Typography } from '@mui/material';
+import { useDeviceTypeStore } from '~/stores/useDeviceTypeStore';
 import { clickableStyle } from '~/styles/designSystem';
 
 type Props = {
@@ -15,6 +16,7 @@ export const Header: React.FC<Props> = ({
   onWordChange,
   onSearchClear,
 }) => {
+  const { isMobile } = useDeviceTypeStore().deviceType;
   const onSearchSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -30,12 +32,12 @@ export const Header: React.FC<Props> = ({
   };
 
   return (
-    <StyledHeader>
+    <StyledHeader $isMobile={isMobile}>
       <Typography variant="h4" sx={{ fontWeight: 'bold' }}>
         문의사항
       </Typography>
 
-      <StyledSearchContainer>
+      <StyledSearchContainer $isMobile={isMobile}>
         {hasSearchWord && (
           <StyledSearchClear onClick={onSearchClear}>
             <ClearIcon fontSize="small" />
@@ -50,7 +52,7 @@ export const Header: React.FC<Props> = ({
             p: '2px 4px',
             display: 'flex',
             alignItems: 'center',
-            width: 490,
+            width: isMobile ? '100%' : 490,
             backgroundColor: '#EBEBEB',
             backgroundImage: '#EBEBEB',
           }}
@@ -71,15 +73,23 @@ export const Header: React.FC<Props> = ({
 
 const SEARCH_INPUT_NAME = 'word';
 
-const StyledHeader = styled.header`
+const StyledHeader = styled.header<{ $isMobile: boolean }>`
   width: 100%;
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: ${({ $isMobile }) => !$isMobile && 'center'};
   margin: 47px 0;
+
+  ${({ $isMobile }) =>
+    $isMobile &&
+    `
+    flex-direction: column;
+    gap : 8px;
+  `}
 `;
 
-const StyledSearchContainer = styled.div`
+const StyledSearchContainer = styled.div<{ $isMobile: boolean }>`
+  ${({ $isMobile }) => $isMobile && 'width: 100%;'}
   display: flex;
   gap: 20px;
 `;

--- a/fe/user/src/pages/InquiryPage/InquiryList/InquiryItem/Mobile.tsx
+++ b/fe/user/src/pages/InquiryPage/InquiryList/InquiryItem/Mobile.tsx
@@ -1,0 +1,90 @@
+import styled from '@emotion/styled';
+import ExpandMoreOutlinedIcon from '@mui/icons-material/ExpandMoreOutlined';
+import { InquiryDetail } from '~/types/api.types';
+import { Inquiry } from '~/types/inquiry.types';
+import { Answer } from './Answer';
+
+type Props = {
+  inquiry: Inquiry;
+  inquiryDetail: InquiryDetail | undefined;
+  updateInquiryDetail: () => void;
+};
+
+export const Mobile: React.FC<Props> = ({
+  inquiry,
+  inquiryDetail,
+  updateInquiryDetail,
+}) => {
+  const { id, status, content } = inquiry;
+  return (
+    <>
+      <StyledDetails onClick={updateInquiryDetail}>
+        <StyledSummary>
+          <div>
+            <div className="inquiry-id">{id.toString().padStart(2, '0')}</div>
+            <StyledStatus>{status}</StyledStatus>
+          </div>
+
+          <StyledSummaryContent>{content}</StyledSummaryContent>
+          <ExpandMoreOutlinedIcon />
+        </StyledSummary>
+
+        {inquiryDetail && (
+          <>
+            <StyledDetailContent>{inquiryDetail.content}</StyledDetailContent>
+            {inquiryDetail.answer?.id && (
+              <Answer
+                updateTime={inquiryDetail.answer.modifiedAt}
+                content={inquiryDetail.answer.content}
+              />
+            )}
+          </>
+        )}
+      </StyledDetails>
+    </>
+  );
+};
+
+const StyledStatus = styled.div`
+  color: #5b5b5b;
+  width: 92px;
+`;
+
+const StyledDetails = styled.details`
+  flex: 1;
+
+  &[open] summary > svg {
+    transform: rotate(180deg);
+  }
+`;
+
+const StyledSummary = styled.summary`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  > svg {
+    transition: transform 0.1s ease-in-out;
+  }
+`;
+
+const StyledSummaryContent = styled.p`
+  font-weight: bold;
+  color: #000000;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+`;
+
+const StyledDetailContent = styled.p`
+  display: block;
+  margin: 30px auto 8px;
+  font-size: 20px;
+`;

--- a/fe/user/src/pages/InquiryPage/InquiryList/InquiryItem/PC.tsx
+++ b/fe/user/src/pages/InquiryPage/InquiryList/InquiryItem/PC.tsx
@@ -1,0 +1,104 @@
+import styled from '@emotion/styled';
+import ExpandMoreOutlinedIcon from '@mui/icons-material/ExpandMoreOutlined';
+import { InquiryDetail } from '~/types/api.types';
+import { Inquiry } from '~/types/inquiry.types';
+import { getFormattedDateString } from '~/utils/dateUtils';
+import { Answer } from './Answer';
+import { Delete } from './Delete';
+
+type Props = {
+  inquiry: Inquiry;
+  inquiryDetail: InquiryDetail | undefined;
+  updateInquiryDetail: () => void;
+};
+
+export const PC: React.FC<Props> = ({
+  inquiry,
+  inquiryDetail,
+  updateInquiryDetail,
+}) => {
+  const { id, content, status, nickname, createdAt } = inquiry;
+  return (
+    <>
+      <div className="inquiry-id">{id.toString().padStart(2, '0')}</div>
+      <StyledStatus>{status}</StyledStatus>
+
+      <StyledDetails onClick={updateInquiryDetail}>
+        <StyledSummary>
+          <StyledSummaryContent>{content}</StyledSummaryContent>
+          <ExpandMoreOutlinedIcon />
+        </StyledSummary>
+
+        {inquiryDetail && (
+          <>
+            <StyledDetailContent>{inquiryDetail.content}</StyledDetailContent>
+            {inquiryDetail.answer?.id && (
+              <Answer
+                updateTime={inquiryDetail.answer.modifiedAt}
+                content={inquiryDetail.answer.content}
+              />
+            )}
+          </>
+        )}
+      </StyledDetails>
+      <>
+        <StyledNickname>{nickname}</StyledNickname>
+        <StyledDate>{getFormattedDateString(createdAt)}</StyledDate>
+        <Delete inquiryId={id} />
+      </>
+    </>
+  );
+};
+
+const StyledStatus = styled.div`
+  color: #5b5b5b;
+  width: 92px;
+`;
+
+const StyledDetails = styled.details`
+  flex: 1;
+
+  &[open] summary > svg {
+    transform: rotate(180deg);
+  }
+`;
+
+const StyledSummary = styled.summary`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  > svg {
+    transition: transform 0.1s ease-in-out;
+  }
+`;
+
+const StyledSummaryContent = styled.p`
+  font-weight: bold;
+  color: #000000;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+`;
+
+const StyledDetailContent = styled.p`
+  display: block;
+  margin: 30px auto 8px;
+  font-size: 20px;
+`;
+
+const StyledNickname = styled.div`
+  color: #363636;
+  width: 100px;
+`;
+
+const StyledDate = styled.div`
+  width: 116px;
+`;

--- a/fe/user/src/pages/InquiryPage/InquiryList/InquiryItem/index.tsx
+++ b/fe/user/src/pages/InquiryPage/InquiryList/InquiryItem/index.tsx
@@ -12,7 +12,7 @@ type Props = {
 };
 
 export const InquiryItem: React.FC<Props> = ({ inquiry }) => {
-  const { isMobile } = useDeviceTypeStore().deviceType;
+  const { isMobile } = useDeviceTypeStore((state) => state.deviceType);
   const [inquiryDetail, setInquiryDetail] = useState<InquiryDetail>();
 
   const updateInquiryDetail = async () => {

--- a/fe/user/src/pages/InquiryPage/InquiryList/InquiryItem/index.tsx
+++ b/fe/user/src/pages/InquiryPage/InquiryList/InquiryItem/index.tsx
@@ -1,20 +1,18 @@
 import styled from '@emotion/styled';
-import ExpandMoreOutlinedIcon from '@mui/icons-material/ExpandMoreOutlined';
 import { useState } from 'react';
 import { getInquiryDetail } from '~/apis/inquiry';
+import { useDeviceTypeStore } from '~/stores/useDeviceTypeStore';
 import { InquiryDetail } from '~/types/api.types';
 import { Inquiry } from '~/types/inquiry.types';
-import { getFormattedDateString } from '~/utils/dateUtils';
-import { Answer } from './Answer';
-import { Delete } from './Delete';
+import { Mobile } from './Mobile';
+import { PC } from './PC';
 
 type Props = {
   inquiry: Inquiry;
 };
 
-export const InquiryItem: React.FC<Props> = ({
-  inquiry: { id, status, content, nickname, createdAt },
-}) => {
+export const InquiryItem: React.FC<Props> = ({ inquiry }) => {
+  const { isMobile } = useDeviceTypeStore().deviceType;
   const [inquiryDetail, setInquiryDetail] = useState<InquiryDetail>();
 
   const updateInquiryDetail = async () => {
@@ -22,36 +20,26 @@ export const InquiryItem: React.FC<Props> = ({
       return;
     }
 
-    const data = await getInquiryDetail(id);
+    const data = await getInquiryDetail(inquiry.id);
 
     setInquiryDetail(data);
   };
 
   return (
     <StyledInquiryItem>
-      <div className="inquiry-id">{id.toString().padStart(2, '0')}</div>
-      <StyledStatus>{status}</StyledStatus>
-      <StyledDetails onClick={updateInquiryDetail}>
-        <StyledSummary>
-          <StyledSummaryContent>{content}</StyledSummaryContent>
-          <ExpandMoreOutlinedIcon />
-        </StyledSummary>
-
-        {inquiryDetail && (
-          <>
-            <StyledDetailContent>{inquiryDetail.content}</StyledDetailContent>
-            {inquiryDetail.answer?.id && (
-              <Answer
-                updateTime={inquiryDetail.answer.modifiedAt}
-                content={inquiryDetail.answer.content}
-              />
-            )}
-          </>
-        )}
-      </StyledDetails>
-      <StyledNickname>{nickname}</StyledNickname>
-      <StyledDate>{getFormattedDateString(createdAt)}</StyledDate>
-      <Delete inquiryId={id} />
+      {isMobile ? (
+        <Mobile
+          inquiry={inquiry}
+          inquiryDetail={inquiryDetail}
+          updateInquiryDetail={updateInquiryDetail}
+        />
+      ) : (
+        <PC
+          inquiry={inquiry}
+          inquiryDetail={inquiryDetail}
+          updateInquiryDetail={updateInquiryDetail}
+        />
+      )}
     </StyledInquiryItem>
   );
 };
@@ -82,57 +70,4 @@ const StyledInquiryItem = styled.li`
       color: #ff4d00;
     }
   }
-`;
-
-const StyledStatus = styled.div`
-  color: #5b5b5b;
-  width: 92px;
-`;
-
-const StyledDetails = styled.details`
-  flex: 1;
-
-  &[open] summary > svg {
-    transform: rotate(180deg);
-  }
-`;
-
-const StyledSummary = styled.summary`
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  gap: 6px;
-  cursor: pointer;
-
-  &:hover {
-    text-decoration: underline;
-  }
-
-  > svg {
-    transition: transform 0.1s ease-in-out;
-  }
-`;
-
-const StyledSummaryContent = styled.p`
-  font-weight: bold;
-  color: #000000;
-  display: -webkit-box;
-  -webkit-line-clamp: 1;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-`;
-
-const StyledDetailContent = styled.p`
-  display: block;
-  margin: 30px auto 8px;
-  font-size: 20px;
-`;
-
-const StyledNickname = styled.div`
-  color: #363636;
-  width: 100px;
-`;
-
-const StyledDate = styled.div`
-  width: 116px;
 `;

--- a/fe/user/src/pages/InquiryPage/index.tsx
+++ b/fe/user/src/pages/InquiryPage/index.tsx
@@ -11,7 +11,7 @@ import { Header } from './Header';
 import { InquiryList } from './InquiryList';
 
 export const InquiryPage: React.FC = () => {
-  const { isMobile } = useDeviceTypeStore().deviceType;
+  const { isMobile } = useDeviceTypeStore((state) => state.deviceType);
 
   const [inquiryParams, setInquiryParams] = useState<InquiryParams>({
     category: '서비스',

--- a/fe/user/src/pages/InquiryPage/index.tsx
+++ b/fe/user/src/pages/InquiryPage/index.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
 import { getInquiryData } from '~/apis/inquiry';
 import { PaginationBox } from '~/components/PaginationBox';
+import { useDeviceTypeStore } from '~/stores/useDeviceTypeStore';
 import { InquiryData, InquiryParams } from '~/types/api.types';
 import { InquiryCategories } from '~/types/inquiry.types';
 import { Categories } from './Categories';
@@ -10,6 +11,8 @@ import { Header } from './Header';
 import { InquiryList } from './InquiryList';
 
 export const InquiryPage: React.FC = () => {
+  const { isMobile } = useDeviceTypeStore().deviceType;
+
   const [inquiryParams, setInquiryParams] = useState<InquiryParams>({
     category: '서비스',
     word: '',
@@ -42,7 +45,7 @@ export const InquiryPage: React.FC = () => {
   }, [inquiryParams]);
 
   return (
-    <StyledDiv>
+    <StyledDiv $isMobile={isMobile}>
       <Header
         hasSearchWord={!!inquiryParams.word}
         onWordChange={onWordChange}
@@ -65,11 +68,17 @@ export const InquiryPage: React.FC = () => {
   );
 };
 
-const StyledDiv = styled.div`
+const StyledDiv = styled.div<{ $isMobile: boolean }>`
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
   align-items: center;
+  ${({ $isMobile }) =>
+    $isMobile &&
+    `  
+    padding: 0 16px;
+    box-sizing: border-box;
+  `}
 `;

--- a/fe/user/src/pages/MainPage/MainSection/CardList/Cards/UpcomingShowCard.tsx
+++ b/fe/user/src/pages/MainPage/MainSection/CardList/Cards/UpcomingShowCard.tsx
@@ -7,7 +7,7 @@ type Props = {
 };
 
 export const UpcomingShowCard: React.FC<Props> = ({ upcomingShow }) => {
-  const { venueId, showId, posterUrl, showName, startTime, endTime } =
+  const { venueId, showId, posterUrl, teamName, startTime, endTime } =
     upcomingShow;
   const navigate = useNavigate();
 
@@ -15,7 +15,7 @@ export const UpcomingShowCard: React.FC<Props> = ({ upcomingShow }) => {
     <StyledCard onClick={() => navigate(`/venues/${venueId}/shows/${showId}`)}>
       <StyledCardImage src={posterUrl} alt="poster" />
       <StyledTitleContainer>
-        <StyledTitle>{showName}</StyledTitle>
+        <StyledTitle>{teamName}</StyledTitle>
         <StyledSubTitle>{`${formatTime(startTime)} ~ ${formatTime(
           endTime,
         )}`}</StyledSubTitle>

--- a/fe/user/src/types/api.types.ts
+++ b/fe/user/src/types/api.types.ts
@@ -49,7 +49,7 @@ export type UpcomingShow = {
   venueId: number;
   showId: number;
   posterUrl: string;
-  showName: string;
+  teamName: string;
 } & ShowTime;
 
 export type HasShowDates = {


### PR DESCRIPTION
## What is this PR? 👓
문의 페이지 모바일 UI 적용

## Key changes 🔑
- 문의 등록 editor 닉네임, 비밀번호 위치를 좌측으로 옮겼습니다.
- 모바일 뷰에서 문의 삭제 버튼을 놓기에는 간격이 너무 좁아서 우선 제외 했습니다.
![image](https://github.com/jazz-meet/jazz-meet/assets/41321198/568759c8-4f1b-433c-9064-495a80b59ae9)
![image](https://github.com/jazz-meet/jazz-meet/assets/41321198/58113aaa-6970-4c3f-b96f-1ae420875ff4)

## To reviewers 👋
- 디자인적으로 변경이 필요하다 생각되는 부분 말씀해 주세요.
