### PR TITLE
공연 상세보기 기능 구현

### DIFF
--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/Calendar.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/Calendar.tsx
@@ -44,7 +44,7 @@ export const Calendar: React.FC<Props> = ({
         <ChevronRightIcon onClick={goToNextMonth} sx={{ fill: '#B5BEC6' }} />
       </StyledCalendarHeader>
       <StyledDaysOfTheWeek>
-        <div>SAN</div>
+        <div>SUN</div>
         <div>MON</div>
         <div>TUE</div>
         <div>WED</div>

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/ShowList.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/ShowList.tsx
@@ -9,6 +9,7 @@ type Props = {
   selectedDate: Date;
   selectPreviousDate: () => void;
   selectNextDate: () => void;
+  onShowListClick: (showInfo: ShowDetail) => void;
 };
 
 export const ShowList: React.FC<Props> = ({
@@ -16,6 +17,7 @@ export const ShowList: React.FC<Props> = ({
   selectedDate,
   selectPreviousDate,
   selectNextDate,
+  onShowListClick,
 }) => {
   const month = selectedDate.getMonth() + 1;
   const date = selectedDate.getDate();
@@ -40,7 +42,10 @@ export const ShowList: React.FC<Props> = ({
 
         {showList &&
           showList.map((show, index) => (
-            <StyledShowListItem key={show.id}>
+            <StyledShowListItem
+              key={show.id}
+              onClick={() => onShowListClick(show)}
+            >
               <StyledShowListItemIndex>
                 {String(index + 1).padStart(2, '0')}
               </StyledShowListItemIndex>

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/ShowList.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/ShowList.tsx
@@ -9,7 +9,7 @@ type Props = {
   selectedDate: Date;
   selectPreviousDate: () => void;
   selectNextDate: () => void;
-  onShowListClick: (showInfo: ShowDetail) => void;
+  onShowListClick: (shows: ShowDetail[], showIndex: number) => void;
 };
 
 export const ShowList: React.FC<Props> = ({
@@ -44,7 +44,7 @@ export const ShowList: React.FC<Props> = ({
           showList.map((show, index) => (
             <StyledShowListItem
               key={show.id}
-              onClick={() => onShowListClick(show)}
+              onClick={() => onShowListClick(showList, index)}
             >
               <StyledShowListItemIndex>
                 {String(index + 1).padStart(2, '0')}

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/ShowList.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/ShowList.tsx
@@ -113,6 +113,11 @@ const StyledShowListItem = styled.div`
   display: flex;
   align-items: center;
   gap: 14px;
+
+  &:hover {
+    background-color: #f2f2f2;
+    cursor: pointer;
+  }
 `;
 
 const StyledShowListItemIndex = styled.div`

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/ShowList.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/ShowList.tsx
@@ -1,15 +1,16 @@
 import styled from '@emotion/styled';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import { ShowDetail } from '~/types/api.types';
+import { useState } from 'react';
+import { ShowDetail as ShowDetailData } from '~/types/api.types';
 import { getKoreanWeekdayName } from '~/utils/dateUtils';
+import { ShowDetail } from '../../ShowDetail';
 
 type Props = {
-  showList?: ShowDetail[];
+  showList?: ShowDetailData[];
   selectedDate: Date;
   selectPreviousDate: () => void;
   selectNextDate: () => void;
-  onShowListClick: (shows: ShowDetail[], showIndex: number) => void;
 };
 
 export const ShowList: React.FC<Props> = ({
@@ -17,12 +18,21 @@ export const ShowList: React.FC<Props> = ({
   selectedDate,
   selectPreviousDate,
   selectNextDate,
-  onShowListClick,
 }) => {
+  const [currentShowIndex, setCurrentShowIndex] = useState(-1);
+
   const month = selectedDate.getMonth() + 1;
   const date = selectedDate.getDate();
   const weekName = getKoreanWeekdayName(selectedDate.getDay());
   const dateString = `${month}월 ${date}일 ${weekName}요일`;
+
+  const openShowDetail = (index: number) => {
+    setCurrentShowIndex(index);
+  };
+
+  const hideShowDetail = () => {
+    setCurrentShowIndex(-1);
+  };
 
   return (
     <StyledShowList>
@@ -44,7 +54,7 @@ export const ShowList: React.FC<Props> = ({
           showList.map((show, index) => (
             <StyledShowListItem
               key={show.id}
-              onClick={() => onShowListClick(showList, index)}
+              onClick={() => openShowDetail(index)}
             >
               <StyledShowListItemIndex>
                 {String(index + 1).padStart(2, '0')}
@@ -58,6 +68,13 @@ export const ShowList: React.FC<Props> = ({
               </StyledShowListItemTime>
             </StyledShowListItem>
           ))}
+        {showList && currentShowIndex !== -1 && (
+          <ShowDetail
+            showList={showList}
+            currentIndex={currentShowIndex}
+            onCloseClick={hideShowDetail}
+          />
+        )}
       </StyledShowListContent>
     </StyledShowList>
   );

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/index.tsx
@@ -6,11 +6,7 @@ import { Calendar } from './Calendar';
 import { ShowList } from './ShowList';
 import { useCalendar } from './useCalendar';
 
-type Props = {
-  onShowListClick: (shows: ShowDetail[], showIndex: number) => void;
-};
-
-export const ShowInfo: React.FC<Props> = ({ onShowListClick }) => {
+export const ShowInfo: React.FC = () => {
   const [showList, setShowList] = useState<ShowDetail[]>();
   const [hasShowDates, setHasShowDates] = useState<HasShowDates>();
   const {
@@ -64,7 +60,6 @@ export const ShowInfo: React.FC<Props> = ({ onShowListClick }) => {
           selectedDate,
           selectPreviousDate,
           selectNextDate,
-          onShowListClick,
         }}
       />
     </>

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/index.tsx
@@ -6,7 +6,9 @@ import { Calendar } from './Calendar';
 import { ShowList } from './ShowList';
 import { useCalendar } from './useCalendar';
 
-type Props = { onShowListClick: (showInfo: ShowDetail) => void };
+type Props = {
+  onShowListClick: (shows: ShowDetail[], showIndex: number) => void;
+};
 
 export const ShowInfo: React.FC<Props> = ({ onShowListClick }) => {
   const [showList, setShowList] = useState<ShowDetail[]>();

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/ShowInfo/index.tsx
@@ -6,7 +6,9 @@ import { Calendar } from './Calendar';
 import { ShowList } from './ShowList';
 import { useCalendar } from './useCalendar';
 
-export const ShowInfo: React.FC = () => {
+type Props = { onShowListClick: (showInfo: ShowDetail) => void };
+
+export const ShowInfo: React.FC<Props> = ({ onShowListClick }) => {
   const [showList, setShowList] = useState<ShowDetail[]>();
   const [hasShowDates, setHasShowDates] = useState<HasShowDates>();
   const {
@@ -55,7 +57,13 @@ export const ShowInfo: React.FC = () => {
         }}
       />
       <ShowList
-        {...{ showList, selectedDate, selectPreviousDate, selectNextDate }}
+        {...{
+          showList,
+          selectedDate,
+          selectPreviousDate,
+          selectNextDate,
+          onShowListClick,
+        }}
       />
     </>
   );

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/index.tsx
@@ -1,15 +1,13 @@
 import styled from '@emotion/styled';
 import LocalCafeOutlinedIcon from '@mui/icons-material/LocalCafeOutlined';
-import { ShowDetail, VenueDetailData } from '~/types/api.types';
+import { VenueDetailData } from '~/types/api.types';
 import { Tabs } from '../Tabs';
 import { Tab } from '../Tabs/Tab';
 import { ShowInfo } from './ShowInfo';
 
-type Props = {
-  onShowListClick: (shows: ShowDetail[], showIndex: number) => void;
-} & Pick<VenueDetailData, 'description'>;
+type Props = Pick<VenueDetailData, 'description'>;
 
-export const RestInfo: React.FC<Props> = ({ onShowListClick, description }) => {
+export const RestInfo: React.FC<Props> = ({ description }) => {
   return (
     <StyledRestInfo>
       <Tabs>
@@ -17,7 +15,7 @@ export const RestInfo: React.FC<Props> = ({ onShowListClick, description }) => {
       </Tabs>
 
       <StyledRestInfoContent>
-        <ShowInfo onShowListClick={onShowListClick} />
+        <ShowInfo />
       </StyledRestInfoContent>
 
       <Tabs>

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/index.tsx
@@ -5,10 +5,9 @@ import { Tabs } from '../Tabs';
 import { Tab } from '../Tabs/Tab';
 import { ShowInfo } from './ShowInfo';
 
-type Props = { onShowListClick: (showInfo: ShowDetail) => void } & Pick<
-  VenueDetailData,
-  'description'
->;
+type Props = {
+  onShowListClick: (shows: ShowDetail[], showIndex: number) => void;
+} & Pick<VenueDetailData, 'description'>;
 
 export const RestInfo: React.FC<Props> = ({ onShowListClick, description }) => {
   return (

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/RestInfo/index.tsx
@@ -1,13 +1,16 @@
 import styled from '@emotion/styled';
 import LocalCafeOutlinedIcon from '@mui/icons-material/LocalCafeOutlined';
-import { VenueDetailData } from '~/types/api.types';
+import { ShowDetail, VenueDetailData } from '~/types/api.types';
 import { Tabs } from '../Tabs';
 import { Tab } from '../Tabs/Tab';
 import { ShowInfo } from './ShowInfo';
 
-type Props = Pick<VenueDetailData, 'description'>;
+type Props = { onShowListClick: (showInfo: ShowDetail) => void } & Pick<
+  VenueDetailData,
+  'description'
+>;
 
-export const RestInfo: React.FC<Props> = ({ description }) => {
+export const RestInfo: React.FC<Props> = ({ onShowListClick, description }) => {
   return (
     <StyledRestInfo>
       <Tabs>
@@ -15,7 +18,7 @@ export const RestInfo: React.FC<Props> = ({ description }) => {
       </Tabs>
 
       <StyledRestInfoContent>
-        <ShowInfo />
+        <ShowInfo onShowListClick={onShowListClick} />
       </StyledRestInfoContent>
 
       <Tabs>

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/ShowDetail/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/ShowDetail/index.tsx
@@ -5,23 +5,28 @@ import CloseIcon from '@mui/icons-material/Close';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useOutletContext } from 'react-router-dom';
-import { ShowDetail as ShowDetailType } from '~/types/api.types';
+import SwiperCore from 'swiper';
+import { Navigation } from 'swiper/modules';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { ShowDetail as ShowDetailData } from '~/types/api.types';
 
 type Props = {
-  showDetailInfo: ShowDetailType;
+  showList: ShowDetailData[];
+  currentIndex: number;
   onCloseClick: () => void;
 };
 
 export const ShowDetail: React.FC<Props> = ({
-  showDetailInfo,
+  showList,
+  currentIndex,
   onCloseClick,
 }) => {
   const mapElement = useOutletContext<React.RefObject<HTMLDivElement>>();
-  const [src, setSrc] = useState('');
+  const [swiper, setSwiper] = useState<SwiperCore>();
 
   useEffect(() => {
-    setSrc(showDetailInfo.posterUrl);
-  }, []);
+    swiper?.slideTo(currentIndex, 0);
+  }, [currentIndex, swiper]);
 
   return (
     <>
@@ -39,20 +44,36 @@ export const ShowDetail: React.FC<Props> = ({
             />
           </StyledShowDetailHeader>
           <StyledShowDetailBody>
-            <ChevronLeftIcon
-              sx={{ width: '64px', height: '64px', fill: '#B5BEC6' }}
-            />
-            <StyledShowDetailContent>
-              <StyledShowDetailImage>
-                <img src={src} alt="poster" />
-              </StyledShowDetailImage>
-              <StyledShowDetailText>
-                {showDetailInfo.description}
-              </StyledShowDetailText>
-            </StyledShowDetailContent>
-            <ChevronRightIcon
-              sx={{ width: '64px', height: '64px', fill: '#B5BEC6' }}
-            />
+            <Swiper
+              modules={[Navigation]}
+              onSwiper={setSwiper}
+              navigation={{
+                prevEl: '.swiper-prev',
+                nextEl: '.swiper-next',
+              }}
+            >
+              {showList.map((show, index) => (
+                <SwiperSlide key={`${show.id}-${index}`}>
+                  <StyledShowDetailContent>
+                    <StyledShowDetailImage>
+                      <img
+                        src={show.posterUrl}
+                        alt={`${show.teamName} 공연 포스터`}
+                      />
+                    </StyledShowDetailImage>
+                    <StyledShowDetailText>
+                      {show.description}
+                    </StyledShowDetailText>
+                  </StyledShowDetailContent>
+                </SwiperSlide>
+              ))}
+            </Swiper>
+            <StyledArrowButton className="swiper-prev">
+              <ChevronLeftIcon sx={{ fill: '#B5BEC6' }} />
+            </StyledArrowButton>
+            <StyledArrowButton className="swiper-next">
+              <ChevronRightIcon sx={{ fill: '#B5BEC6' }} />
+            </StyledArrowButton>
           </StyledShowDetailBody>
         </StyledShowDetail>,
         mapElement.current ?? document.body,
@@ -77,10 +98,14 @@ const StyledShowDetailHeader = styled.div`
 `;
 
 const StyledShowDetailBody = styled.div`
+  position: relative;
   height: 100%;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  justify-content: center;
+
+  & > .swiper {
+    width: 80%;
+  }
 `;
 
 const StyledShowDetailContent = styled.div`
@@ -122,4 +147,30 @@ const StyledShowDetailText = styled.div`
   font-size: 20px;
   line-height: 130%;
   margin-bottom: 100px;
+`;
+
+const StyledArrowButton = styled.button`
+  position: absolute;
+  top: 40%;
+
+  &:hover {
+    cursor: pointer;
+  }
+
+  > svg {
+    width: 64px;
+    height: 64px;
+  }
+
+  &.swiper-prev {
+    left: -3%;
+  }
+
+  &.swiper-next {
+    right: -3%;
+  }
+
+  &.swiper-button-disabled {
+    opacity: 0.2;
+  }
 `;

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/ShowDetail/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/ShowDetail/index.tsx
@@ -29,7 +29,12 @@ export const ShowDetail: React.FC<Props> = ({
         <StyledShowDetail>
           <StyledShowDetailHeader>
             <CloseIcon
-              sx={{ width: '64px', height: '64px', fill: '#B5BEC6' }}
+              sx={{
+                width: '32px',
+                height: '32px',
+                fill: '#B5BEC6',
+                '&:hover': { cursor: 'pointer', opacity: 0.7 },
+              }}
               onClick={onCloseClick}
             />
           </StyledShowDetailHeader>
@@ -87,6 +92,21 @@ const StyledShowDetailContent = styled.div`
   flex-direction: column;
   align-items: center;
   gap: 20px;
+
+  &::-webkit-scrollbar {
+    width: 18px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-clip: padding-box;
+    background-color: #c1c1c1;
+    border-radius: 10px;
+    border: 6px solid transparent;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
 `;
 
 const StyledShowDetailImage = styled.div`

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/ShowDetail/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/ShowDetail/index.tsx
@@ -1,20 +1,26 @@
 import styled from '@emotion/styled';
-import { useEffect, useState } from 'react';
-import { createPortal } from 'react-dom';
-import { useOutletContext } from 'react-router-dom';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import CloseIcon from '@mui/icons-material/Close';
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useOutletContext } from 'react-router-dom';
+import { ShowDetail as ShowDetailType } from '~/types/api.types';
 
-export const ShowDetail: React.FC = () => {
-  // const { id: showId } = useParams();
+type Props = {
+  showDetailInfo: ShowDetailType;
+  onCloseClick: () => void;
+};
+
+export const ShowDetail: React.FC<Props> = ({
+  showDetailInfo,
+  onCloseClick,
+}) => {
   const mapElement = useOutletContext<React.RefObject<HTMLDivElement>>();
   const [src, setSrc] = useState('');
 
   useEffect(() => {
-    setSrc(
-      'https://github.com/jazz-meet/jazz-meet/assets/57666791/7beb1dbf-54cb-407a-9494-9ee45e0bb38d',
-    );
+    setSrc(showDetailInfo.posterUrl);
   }, []);
 
   return (
@@ -24,6 +30,7 @@ export const ShowDetail: React.FC = () => {
           <StyledShowDetailHeader>
             <CloseIcon
               sx={{ width: '64px', height: '64px', fill: '#B5BEC6' }}
+              onClick={onCloseClick}
             />
           </StyledShowDetailHeader>
           <StyledShowDetailBody>
@@ -35,12 +42,7 @@ export const ShowDetail: React.FC = () => {
                 <img src={src} alt="poster" />
               </StyledShowDetailImage>
               <StyledShowDetailText>
-                올댓재즈는 1976년부터 한국의 재즈씬을 이끌어온 한국의
-                대표브랜드로서 재즈 매니아들의 성지와도 같은 공간입니다.
-                올댓재즈는 1976년부터 한국의 재즈씬을 이끌어온 한국의
-                대표브랜드로서 재즈 매니아들의 성지와도 같은 공간입니다.
-                올댓재즈는 1976년부터 한국의 재즈씬을 이끌어온 한국의
-                대표브랜드로서 재즈 매니아들의 성지와도 같은 공간입니다.
+                {showDetailInfo.description}
               </StyledShowDetailText>
             </StyledShowDetailContent>
             <ChevronRightIcon

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/ShowDetail/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/ShowDetail/index.tsx
@@ -61,9 +61,11 @@ export const ShowDetail: React.FC<Props> = ({
                         alt={`${show.teamName} 공연 포스터`}
                       />
                     </StyledShowDetailImage>
-                    <StyledShowDetailText>
-                      {show.description}
-                    </StyledShowDetailText>
+                    {show.description && (
+                      <StyledShowDetailText>
+                        {show.description}
+                      </StyledShowDetailText>
+                    )}
                   </StyledShowDetailContent>
                 </SwiperSlide>
               ))}
@@ -105,6 +107,11 @@ const StyledShowDetailBody = styled.div`
 
   & > .swiper {
     width: 80%;
+  }
+
+  .swiper-slide {
+    display: flex;
+    justify-content: center;
   }
 `;
 

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/index.tsx
@@ -10,11 +10,15 @@ import {
 } from 'react-router-dom';
 import { getVenueDetail } from '~/apis/venue';
 import CaretLeft from '~/assets/icons/CaretLeft.svg?react';
-import { VenueDetailData } from '~/types/api.types';
+import {
+  ShowDetail as ShowDetailType,
+  VenueDetailData,
+} from '~/types/api.types';
 import { BasicInfo } from './BasicInfo';
 import { Header } from './Header';
 import { Images } from './Images';
 import { RestInfo } from './RestInfo';
+import { ShowDetail } from './ShowDetail';
 
 export const VenueDetail: React.FC = () => {
   const { venueId } = useParams();
@@ -23,9 +27,20 @@ export const VenueDetail: React.FC = () => {
   const mapElement = useOutletContext<React.RefObject<HTMLDivElement>>();
   const [isRender, setRender] = useState(false);
   const [data, setData] = useState<VenueDetailData>();
+  const [isShowDetailOpen, setIsShowDetailOpen] = useState(false);
+  const [showDetailInfo, setShowDetailInfo] = useState<ShowDetailType>();
 
   const backToVenueList = () => {
     navigate(`/map?${currentLocation.search}`);
+  };
+
+  const openShowDetail = (showInfo: ShowDetailType) => {
+    setShowDetailInfo(showInfo);
+    setIsShowDetailOpen(true);
+  };
+
+  const hideShowDetail = () => {
+    setIsShowDetailOpen(false);
   };
 
   useEffect(() => {
@@ -72,9 +87,18 @@ export const VenueDetail: React.FC = () => {
               data.links.find((link) => link.type === 'naverMap')?.url
             }
           />
-          <RestInfo description={data.description} />
+          <RestInfo
+            description={data.description}
+            onShowListClick={openShowDetail}
+          />
           <Outlet context={mapElement} />
-          {/* {showInfoDetail && createPortal(<Images />)} */}
+          {isShowDetailOpen && showDetailInfo && (
+            <ShowDetail
+              key={showDetailInfo.id}
+              showDetailInfo={showDetailInfo}
+              onCloseClick={hideShowDetail}
+            />
+          )}
         </StyledVenueDetail>
       )}
     </>

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/index.tsx
@@ -10,15 +10,11 @@ import {
 } from 'react-router-dom';
 import { getVenueDetail } from '~/apis/venue';
 import CaretLeft from '~/assets/icons/CaretLeft.svg?react';
-import {
-  ShowDetail as ShowDetailData,
-  VenueDetailData,
-} from '~/types/api.types';
+import { VenueDetailData } from '~/types/api.types';
 import { BasicInfo } from './BasicInfo';
 import { Header } from './Header';
 import { Images } from './Images';
 import { RestInfo } from './RestInfo';
-import { ShowDetail } from './ShowDetail';
 
 export const VenueDetail: React.FC = () => {
   const { venueId } = useParams();
@@ -27,21 +23,9 @@ export const VenueDetail: React.FC = () => {
   const mapElement = useOutletContext<React.RefObject<HTMLDivElement>>();
   const [isRender, setRender] = useState(false);
   const [data, setData] = useState<VenueDetailData>();
-  const [showList, setShowList] = useState<ShowDetailData[]>([]);
-  const [currentShowIndex, setCurrentShowIndex] = useState(-1);
 
   const backToVenueList = () => {
     navigate(`/map?${currentLocation.search}`);
-  };
-
-  const openShowDetail = (shows: ShowDetailData[], showIndex: number) => {
-    setShowList(shows);
-    setCurrentShowIndex(showIndex);
-  };
-
-  const hideShowDetail = () => {
-    setShowList([]);
-    setCurrentShowIndex(-1);
   };
 
   useEffect(() => {
@@ -88,18 +72,8 @@ export const VenueDetail: React.FC = () => {
               data.links.find((link) => link.type === 'naverMap')?.url
             }
           />
-          <RestInfo
-            description={data.description}
-            onShowListClick={openShowDetail}
-          />
+          <RestInfo description={data.description} />
           <Outlet context={mapElement} />
-          {showList.length > 0 && currentShowIndex !== -1 && (
-            <ShowDetail
-              showList={showList}
-              currentIndex={currentShowIndex}
-              onCloseClick={hideShowDetail}
-            />
-          )}
         </StyledVenueDetail>
       )}
     </>

--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/index.tsx
@@ -11,7 +11,7 @@ import {
 import { getVenueDetail } from '~/apis/venue';
 import CaretLeft from '~/assets/icons/CaretLeft.svg?react';
 import {
-  ShowDetail as ShowDetailType,
+  ShowDetail as ShowDetailData,
   VenueDetailData,
 } from '~/types/api.types';
 import { BasicInfo } from './BasicInfo';
@@ -27,20 +27,21 @@ export const VenueDetail: React.FC = () => {
   const mapElement = useOutletContext<React.RefObject<HTMLDivElement>>();
   const [isRender, setRender] = useState(false);
   const [data, setData] = useState<VenueDetailData>();
-  const [isShowDetailOpen, setIsShowDetailOpen] = useState(false);
-  const [showDetailInfo, setShowDetailInfo] = useState<ShowDetailType>();
+  const [showList, setShowList] = useState<ShowDetailData[]>([]);
+  const [currentShowIndex, setCurrentShowIndex] = useState(-1);
 
   const backToVenueList = () => {
     navigate(`/map?${currentLocation.search}`);
   };
 
-  const openShowDetail = (showInfo: ShowDetailType) => {
-    setShowDetailInfo(showInfo);
-    setIsShowDetailOpen(true);
+  const openShowDetail = (shows: ShowDetailData[], showIndex: number) => {
+    setShowList(shows);
+    setCurrentShowIndex(showIndex);
   };
 
   const hideShowDetail = () => {
-    setIsShowDetailOpen(false);
+    setShowList([]);
+    setCurrentShowIndex(-1);
   };
 
   useEffect(() => {
@@ -92,10 +93,10 @@ export const VenueDetail: React.FC = () => {
             onShowListClick={openShowDetail}
           />
           <Outlet context={mapElement} />
-          {isShowDetailOpen && showDetailInfo && (
+          {showList.length > 0 && currentShowIndex !== -1 && (
             <ShowDetail
-              key={showDetailInfo.id}
-              showDetailInfo={showDetailInfo}
+              showList={showList}
+              currentIndex={currentShowIndex}
               onCloseClick={hideShowDetail}
             />
           )}

--- a/fe/user/src/router.tsx
+++ b/fe/user/src/router.tsx
@@ -8,7 +8,6 @@ import { InquiryPage } from './pages/InquiryPage';
 import { MainPage } from './pages/MainPage';
 import { MapPage } from './pages/MapPage';
 import { VenueDetail } from './pages/MapPage/Panel/VenueDetail';
-import { ShowDetail } from './pages/MapPage/Panel/VenueDetail/ShowDetail';
 import { ShowPage } from './pages/ShowPage';
 
 export const router = createBrowserRouter(
@@ -17,9 +16,7 @@ export const router = createBrowserRouter(
       <Route element={<BaseLayout />}>
         <Route index element={<MainPage />} />
         <Route path="map" element={<MapPage />}>
-          <Route path="venues/:venueId" element={<VenueDetail />}>
-            <Route path="shows/:showId" element={<ShowDetail />} />
-          </Route>
+          <Route path="venues/:venueId" element={<VenueDetail />} />
         </Route>
         <Route path="show" element={<ShowPage />} />
         <Route path="inquiry" element={<InquiryPage />} />


### PR DESCRIPTION
## What is this PR? 👓
공연장 상세보기에서 공연 목록을 클릭하면 포스터와 상세 내용을 보여주는 기능입니다.
좌우 화살표로 오늘 공연 목록을 탐색할 수 있습니다.

## Key changes 🔑
- ShowLIst 항목 클릭 시 showList, index를 ShowDetail 컴포넌트로 전달
- poster, description 보여줌.
- 공연 내용이 길어질 경우 스크롤바 생성

![공연-상세보기](https://github.com/jazz-meet/jazz-meet/assets/60080167/d245f4d8-ad7e-4af8-9ce9-d094ad6f65e1)


## To reviewers 👋
- 날짜를 변경하면 변경한 날짜의 공연 내용들로 교체되게 하는게 좋을까요? 의견주세요.
- 포스터 로딩시에 딜레이 발생
