### PR TITLE
첫 렌더링시 device type 체크 못하는 이슈 및 SearchBox UI 수정

### DIFF
--- a/fe/user/src/components/DeviceTypeChecker.tsx
+++ b/fe/user/src/components/DeviceTypeChecker.tsx
@@ -1,23 +1,17 @@
 import { useEffect } from 'react';
 import { useDeviceTypeStore } from '~/stores/useDeviceTypeStore';
 
-const MOBILE_MAX_WIDTH = 1023;
-
 export const DeviceTypeChecker: React.FC = () => {
-  const { setDeviceType } = useDeviceTypeStore();
+  const updateDeviceType = useDeviceTypeStore(
+    (state) => state.updateDeviceType,
+  );
 
   useEffect(() => {
-    const handleResize = () => {
-      const { innerWidth } = window;
-      const isMobile = innerWidth <= MOBILE_MAX_WIDTH;
-
-      setDeviceType({ isMobile });
-    };
-
-    window.addEventListener('resize', handleResize);
+    updateDeviceType();
+    window.addEventListener('resize', updateDeviceType);
 
     return () => {
-      window.removeEventListener('resize', handleResize);
+      window.removeEventListener('resize', updateDeviceType);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/fe/user/src/components/DeviceTypeChecker.tsx
+++ b/fe/user/src/components/DeviceTypeChecker.tsx
@@ -13,8 +13,7 @@ export const DeviceTypeChecker: React.FC = () => {
     return () => {
       window.removeEventListener('resize', updateDeviceType);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [updateDeviceType]);
 
   return null;
 };

--- a/fe/user/src/layouts/MobileLayout/Header.tsx
+++ b/fe/user/src/layouts/MobileLayout/Header.tsx
@@ -74,6 +74,7 @@ const StyledSearchContainer = styled.div`
 
 const StyledSearchBoxContainer = styled.div`
   width: 90%;
+  max-width: 490px;
   z-index: ${SEARCH_BOX_Z_INDEX};
   position: fixed;
   top: 100px;

--- a/fe/user/src/stores/useDeviceTypeStore.ts
+++ b/fe/user/src/stores/useDeviceTypeStore.ts
@@ -3,12 +3,20 @@ import { DeviceType } from '~/types/device.types';
 
 type DeviceTypeState = {
   deviceType: DeviceType;
-  setDeviceType: (deviceType: DeviceType) => void;
+  updateDeviceType: () => void;
 };
+
+const MOBILE_MAX_WIDTH = 1023;
 
 export const useDeviceTypeStore = create<DeviceTypeState>((set) => ({
   deviceType: {
     isMobile: false,
   },
-  setDeviceType: (deviceType: DeviceType) => set(() => ({ deviceType })),
+  updateDeviceType: () =>
+    set((state) => {
+      const { innerWidth } = window;
+      const isMobile = innerWidth <= MOBILE_MAX_WIDTH;
+
+      return { deviceType: { ...state.deviceType, isMobile } };
+    }),
 }));


### PR DESCRIPTION
## What is this PR? 👓
첫 렌더링시 device type 체크 못하는 이슈 및 SearchBox UI 수정 #254

## Key changes 🔑
- useDeviceTypeStore에서 setter를 내보내는 것이 아닌 store 자체적으로 로직을 가지고 업데이트 함수만 내보내어 사용처에서 호출만 하면 되도록 수정 했습니다.
- DeviceTypeChecker가 호출되면 바로 디바이스 타입을 찾도록 수정했습니다.
- view-width 490px 이상인 경우 검색창의 레이아웃이 깨지는 현상 수정했습니다.

## To reviewers 👋
