### PR TITLE
지도페이지 버튼 레이아웃 수정

### DIFF
--- a/fe/user/src/pages/MapPage/Map/MapSearchButton.tsx
+++ b/fe/user/src/pages/MapPage/Map/MapSearchButton.tsx
@@ -28,7 +28,7 @@ const StyledMapSearchButton = styled.button`
   position: absolute;
   bottom: 8%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translateX(-50%) translateY(-50%);
   z-index: ${MAP_SEARCH_BUTTON_Z_INDEX};
   padding: 12px 16px;
   border-radius: 50px;

--- a/fe/user/src/pages/MapPage/index.tsx
+++ b/fe/user/src/pages/MapPage/index.tsx
@@ -137,8 +137,7 @@ const MY_LOCATION_BUTTON = 'my-location-button';
 
 const StyledMapPage = styled.div<{ isMobile: boolean }>`
   overflow: hidden;
-  height: ${({ isMobile }) =>
-    isMobile ? 'calc(100vh - 73px - 47px)' : 'calc(100vh - 73px)'};
+  height: ${({ isMobile }) => (isMobile ? 'calc(100% - 60px)' : '100%')};
   display: flex;
 
   .${MY_LOCATION_BUTTON} {

--- a/fe/user/src/styles/reset.css
+++ b/fe/user/src/styles/reset.css
@@ -133,3 +133,9 @@ button {
   border: 0;
   background: inherit;
 }
+
+html,
+body,
+#root {
+  height: 100%;
+}


### PR DESCRIPTION
## What is this PR? 👓
지도페이지 버튼 레이아웃 수정

## Key changes 🔑
html, body, #root height 100% 추가
현 지도 검색버튼 css 수정

## To reviewers 👋
모바일에서 100vh 설정시 주소창, 하단바까지 포함되어 계산되기 때문에 버튼들이 안보였습니다.

html, body, #root에 height 100% 주고 맵에 높이를 계산하는 방식으로 수정하였습니다.