### PR TITLE
Be/feat/#273 공연 스케줄 자동화

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -65,8 +65,12 @@ dependencies {
 
     // configuring annotation processor
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+
     // json
     implementation 'org.json:json:20230227'
+
+    // selenium
+    implementation 'org.seleniumhq.selenium:selenium-java:4.8.3'
 
 }
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/address/service/AddressService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/address/service/AddressService.java
@@ -26,7 +26,7 @@ import lombok.extern.log4j.Log4j2;
 public class AddressService {
 
 	@Value("${address.endpoint}")
-	private String ENDPOINT;
+	private String endpoint;
 	@Value("${address.client.id}")
 	private String clientId;
 	@Value("${address.client.secret}")
@@ -37,18 +37,18 @@ public class AddressService {
 			throw new CustomException(AddressErrorCode.WORD_IS_EMPTY);
 		}
 		// 네이버에 요청을 보낸다.
-		StringBuffer response = sendRequestAndGetResponse(word, page);
+		StringBuffer response = sendRequest(word, page);
 		// 받은 response를 원하는 response 형태로 만들기.
 		return toLocationSearchResponse(response);
 	}
 
-	private StringBuffer sendRequestAndGetResponse(String word, int page) {
+	private StringBuffer sendRequest(String word, int page) {
 		HttpURLConnection conn = null;
 
 		try {
 			String address = URLEncoder.encode(word, StandardCharsets.UTF_8);
 			String pageNum = URLEncoder.encode(String.valueOf(page), StandardCharsets.UTF_8);
-			String apiUrl = ENDPOINT + "?query=" + address + "&page=" + pageNum;
+			String apiUrl = endpoint + "?query=" + address + "&page=" + pageNum;
 
 			URL url = new URL(apiUrl);
 			conn = (HttpURLConnection)url.openConnection();

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ShowErrorCode.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ShowErrorCode.java
@@ -8,7 +8,17 @@ import lombok.RequiredArgsConstructor;
 public enum ShowErrorCode implements StatusCode {
 
 	NOT_VALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "날짜 포맷이 잘못되었습니다. 'yyyyMMdd' 형식으로 입력해주세요"),
-	NOT_FOUND_SHOW(HttpStatus.NOT_FOUND, "해당하는 공연이 없습니다.");
+	NOT_FOUND_SHOW(HttpStatus.NOT_FOUND, "해당하는 공연이 없습니다."),
+	// 웹 크롤링 실패
+	CRAWLING_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 URL 추출에 실패했습니다."),
+	NOT_FOUND_SHOW_IMAGE_URL(HttpStatus.EXPECTATION_FAILED, "해당하는 이미지 url을 찾지 못했습니다."),
+	// OCR 실패
+	OCR_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OCR 요청이 실패했습니다."),
+	OCR_NOT_MATCHED_VENUE_AND_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "자동 인식 된 OCR 템플릿이 공연장과 일치하지 않습니다."),
+	OCR_EXTRACTION_FAILED_SHOW_DATE(HttpStatus.INTERNAL_SERVER_ERROR, "OCR 공연 날짜 인식 및 추출에 실패했습니다."),
+	OCR_EXTRACTION_FAILED_ARTISTS_AND_DETAILS(HttpStatus.INTERNAL_SERVER_ERROR, "OCR 아티스트와 상세 정보 인식 및 추출에 실패했습니다."),
+	OCR_NOT_LATEST_SHOW(HttpStatus.EXPECTATION_FAILED, "OCR로 추출한 날짜가 공연의 최신 날짜가 아닙니다."),
+	OBJECT_TRANSFORMATION_FAILD(HttpStatus.EXPECTATION_FAILED, "객체 변환에 실패했습니다. (JSON -> RegisterShowRequest)");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ShowErrorCode.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ShowErrorCode.java
@@ -18,7 +18,9 @@ public enum ShowErrorCode implements StatusCode {
 	OCR_EXTRACTION_FAILED_SHOW_DATE(HttpStatus.INTERNAL_SERVER_ERROR, "OCR 공연 날짜 인식 및 추출에 실패했습니다."),
 	OCR_EXTRACTION_FAILED_ARTISTS_AND_DETAILS(HttpStatus.INTERNAL_SERVER_ERROR, "OCR 아티스트와 상세 정보 인식 및 추출에 실패했습니다."),
 	OCR_NOT_LATEST_SHOW(HttpStatus.EXPECTATION_FAILED, "OCR로 추출한 날짜가 공연의 최신 날짜가 아닙니다."),
-	OBJECT_TRANSFORMATION_FAILD(HttpStatus.EXPECTATION_FAILED, "객체 변환에 실패했습니다. (JSON -> RegisterShowRequest)");
+	OBJECT_TRANSFORMATION_FAILD(HttpStatus.EXPECTATION_FAILED, "객체 변환에 실패했습니다. (JSON -> RegisterShowRequest)"),
+	OCR_NOT_EQUAL_TEAMS_AND_POSTER_NUMBERS(HttpStatus.EXPECTATION_FAILED, "팀의 수와 포스터의 수가 일치하지 않습니다."),
+	OCR_IMAGE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 url를 파일로 변환하는데 실패했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/util/CustomLocalDate.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/util/CustomLocalDate.java
@@ -1,0 +1,25 @@
+package kr.codesquad.jazzmeet.global.util;
+
+import java.time.LocalDate;
+import java.time.Month;
+
+public class CustomLocalDate {
+
+	// 파싱해 온 공연 날짜 생성
+	public static LocalDate of(Month month, Integer dayOfMonth) {
+		LocalDate now = LocalDate.now();
+		int showYear = now.getYear();
+		// 오늘이 11월이나 12월이고, 공연 날짜가 1월이나 2월이면 공연의 연도를 내년으로 설정.
+		if ((now.getMonth().equals(Month.NOVEMBER) || now.getMonth().equals(Month.DECEMBER))
+			&& (month.equals(Month.JANUARY) || month.equals(Month.FEBRUARY))) {
+			showYear += 1;
+		}
+
+		// 오늘이 1월이고, 공연 날짜가 12월이면 공연의 연도를 작년으로 설정.
+		if (now.getMonth().equals(Month.JANUARY) && month.equals(Month.DECEMBER)) {
+			showYear -= 1;
+		}
+
+		return LocalDate.of(showYear, month, dayOfMonth);
+	}
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/util/CustomMultipartFile.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/util/CustomMultipartFile.java
@@ -1,0 +1,70 @@
+package kr.codesquad.jazzmeet.global.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public class CustomMultipartFile implements MultipartFile {
+	private final byte[] bytes;
+	String name;
+	String originalFilename;
+	String contentType;
+	boolean isEmpty;
+	long size;
+
+	public CustomMultipartFile(byte[] bytes, String name, String originalFilename, String contentType,
+		long size) {
+		this.bytes = bytes;
+		this.name = name;
+		this.originalFilename = originalFilename;
+		this.contentType = contentType;
+		this.size = size;
+		this.isEmpty = false;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String getOriginalFilename() {
+		return originalFilename;
+	}
+
+	@Override
+	public String getContentType() {
+		return contentType;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return isEmpty;
+	}
+
+	@Override
+	public long getSize() {
+		return size;
+	}
+
+	@Override
+	public byte[] getBytes() throws IOException {
+		return bytes;
+	}
+
+	@Override
+	public InputStream getInputStream() throws IOException {
+		return new ByteArrayInputStream(bytes);
+	}
+
+	@Override
+	public void transferTo(File destination) throws IOException, IllegalStateException {
+		try (FileOutputStream fos = new FileOutputStream(destination)) {
+			fos.write(bytes);
+		}
+	}
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/util/TextParser.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/util/TextParser.java
@@ -1,0 +1,24 @@
+package kr.codesquad.jazzmeet.global.util;
+
+import java.time.Month;
+import java.util.Arrays;
+import java.util.List;
+
+public class TextParser {
+
+	public static Month getMonth(String text) {
+		return Month.of(parse(text).get(0));
+	}
+
+	public static Integer getDayOfMonth(String text) {
+		return parse(text).get(1);
+	}
+
+	private static List<Integer> parse(String text) {
+		// text = "12.27 - 12.31"
+		String[] showStartEndDate = text.replace(" ", "").split("-");
+
+		return Arrays.stream(showStartEndDate[0].split("\\."))
+			.map(Integer::parseInt).toList();
+	}
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/util/WebDriverUtil.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/util/WebDriverUtil.java
@@ -40,6 +40,7 @@ public class WebDriverUtil {
 		// ⭐️ WebDriver를 크롬으로 생각하고 사용한다.
 		WebDriver driver = new ChromeDriver(chromeOptions);
 		driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(30));
+
 		return driver;
 	}
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/util/WebDriverUtil.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/util/WebDriverUtil.java
@@ -1,0 +1,62 @@
+package kr.codesquad.jazzmeet.global.util;
+
+import java.time.Duration;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+
+import lombok.RequiredArgsConstructor;
+
+/*
+	- 크롬 드라이버 생성, 크롬 옵션 설정, 크롬 드라이버의 설치 경로 WEB_DRIVER_PATH 설정
+	‼️ 크롬과 드라이버의 버전이 동일해야 한다
+ */
+@RequiredArgsConstructor
+@Component
+public class WebDriverUtil {
+	private static final String WEB_DRIVER_ID = "webdriver.chrome.driver";
+	private static String WEB_DRIVER_PATH; // WebDriver 경로
+
+	public static WebDriver getChromeDriver() {
+		// webDriver 설정
+		if (ObjectUtils.isEmpty(System.getProperty(WEB_DRIVER_ID))) {
+			System.setProperty(WEB_DRIVER_ID, WEB_DRIVER_PATH);
+		}
+		// 크롬 설정을 담은 객체 생성
+		ChromeOptions chromeOptions = new ChromeOptions();
+		// 브라우저가 눈에 보이지 않고 내부적으로 실행된다.
+		chromeOptions.addArguments("headless");
+		chromeOptions.addArguments("--lang=ko");
+		chromeOptions.addArguments("--no-sandbox");
+		chromeOptions.addArguments("--disable-dev-shm-usage");
+		chromeOptions.addArguments("--disable-gpu");
+		chromeOptions.setCapability("ignoreProtectedModeSettings", true);
+		// 위 옵션을 담은 드라이버 객체 생성.
+		// 옵션을 설정하지 않았다면 생략 가능하다.
+		// ⭐️ WebDriver를 크롬으로 생각하고 사용한다.
+		WebDriver driver = new ChromeDriver(chromeOptions);
+		driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(30));
+		return driver;
+	}
+
+	@Value("${driver.chrome.driver.path}")
+	public void setWebDriverPath(String path) {
+		WEB_DRIVER_PATH = path;
+	}
+
+	public static void quit(WebDriver driver) {
+		if (!ObjectUtils.isEmpty(driver)) {
+			driver.quit();
+		}
+	}
+
+	public static void close(WebDriver driver) {
+		if (!ObjectUtils.isEmpty(driver)) {
+			driver.close();
+		}
+	}
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/controller/ImageController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/controller/ImageController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import kr.codesquad.jazzmeet.image.dto.response.ImageCreateResponse;
+import kr.codesquad.jazzmeet.image.entity.ImageStatus;
 import kr.codesquad.jazzmeet.image.service.CloudService;
 import kr.codesquad.jazzmeet.image.service.ImageService;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +30,8 @@ public class ImageController {
 	@PostMapping("/api/images")
 	public ResponseEntity<ImageCreateResponse> uploadImages(@RequestPart("image") List<MultipartFile> multipartFiles) {
 		List<String> imageUrls = cloudService.uploadImages(multipartFiles);
-		ImageCreateResponse imageCreateResponse = imageService.saveImages(imageUrls);
+		ImageStatus imageStatus = ImageStatus.UNREGISTERED;
+		ImageCreateResponse imageCreateResponse = imageService.saveImages(imageUrls, imageStatus);
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(imageCreateResponse);
 	}

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
@@ -26,9 +26,9 @@ public class ImageService {
 	private final ImageQueryRepository imageQueryRepository;
 
 	@Transactional
-	public ImageCreateResponse saveImages(List<String> imageUrls) {
+	public ImageCreateResponse saveImages(List<String> imageUrls, ImageStatus imageStatus) {
 		List<Image> images = imageUrls.stream()
-			.map(url -> ImageMapper.INSTANCE.toImage(url, ImageStatus.UNREGISTERED))
+			.map(url -> ImageMapper.INSTANCE.toImage(url, imageStatus))
 			.toList();
 
 		List<Image> saveImages = imageRepository.saveAll(images);

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/controller/ShowController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/controller/ShowController.java
@@ -24,6 +24,7 @@ import kr.codesquad.jazzmeet.show.dto.response.ShowByDateResponse;
 import kr.codesquad.jazzmeet.show.dto.response.ShowDetailResponse;
 import kr.codesquad.jazzmeet.show.dto.response.ShowResponse;
 import kr.codesquad.jazzmeet.show.dto.response.UpcomingShowResponse;
+import kr.codesquad.jazzmeet.show.service.ShowScheduler;
 import kr.codesquad.jazzmeet.show.service.ShowService;
 import lombok.RequiredArgsConstructor;
 
@@ -32,6 +33,7 @@ import lombok.RequiredArgsConstructor;
 public class ShowController {
 
 	private final ShowService showService;
+	private final ShowScheduler showScheduler;
 
 	/**
 	 * 진행 중인 공연 조회 API
@@ -136,5 +138,12 @@ public class ShowController {
 		showService.deleteShow(showId);
 
 		return ResponseEntity.noContent().build();
+	}
+
+	@GetMapping("/api/crawling-test")
+	public ResponseEntity<Void> crawling_test() {
+		showScheduler.autoInsertShowSchedule();
+
+		return ResponseEntity.ok().build();
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/controller/ShowController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/controller/ShowController.java
@@ -139,11 +139,4 @@ public class ShowController {
 
 		return ResponseEntity.noContent().build();
 	}
-
-	@GetMapping("/api/crawling-test")
-	public ResponseEntity<Void> crawling_test() {
-		showScheduler.autoInsertShowSchedule();
-
-		return ResponseEntity.ok().build();
-	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/dto/request/RegisterShowRequest.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/dto/request/RegisterShowRequest.java
@@ -13,7 +13,6 @@ public record RegisterShowRequest(
 	String teamName,
 	@Size(max = 1000, message = "설명은 1000자까지 입력 가능합니다.")
 	String description,
-	@NotNull(message = "poster id를 입력해주세요.")
 	Long posterId,
 	LocalDateTime startTime,
 	LocalDateTime endTime

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
@@ -1,5 +1,7 @@
 package kr.codesquad.jazzmeet.show.mapper;
 
+import java.time.LocalDateTime;
+
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -38,4 +40,7 @@ public interface ShowMapper {
 
 	@Mapping(target = "description", source = "registerShowRequest.description")
 	Show toShow(RegisterShowRequest registerShowRequest, Venue venue, Image poster);
+
+	RegisterShowRequest toRegisterShowRequest(String teamName, String description, Long posterId,
+		LocalDateTime startTime, LocalDateTime endTime);
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
@@ -30,6 +30,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import kr.codesquad.jazzmeet.global.error.CustomException;
 import kr.codesquad.jazzmeet.global.error.statuscode.ShowErrorCode;
+import kr.codesquad.jazzmeet.global.util.CustomLocalDate;
 import kr.codesquad.jazzmeet.global.util.CustomMultipartFile;
 import kr.codesquad.jazzmeet.image.dto.response.ImageCreateResponse;
 import kr.codesquad.jazzmeet.image.dto.response.ImageSaveResponse;
@@ -182,22 +183,10 @@ public class OcrHandler {
 		String[] showStartEndDate = showStartEndDateText.replace(" ", "").split("-");
 		List<Integer> showStartMonthDay = Arrays.stream(showStartEndDate[0].split("\\."))
 			.map(Integer::parseInt).toList();
-		Month showStartMonth = Month.of(showStartMonthDay.get(0));
-		Integer showStartDay = showStartMonthDay.get(1);
-		LocalDate now = LocalDate.now();
-		int showYear = now.getYear();
-		// 오늘이 11월이나 12월이고, 공연 날짜가 1월이나 2월이면 공연의 연도를 내년으로 설정.
-		if ((now.getMonth().equals(Month.NOVEMBER) || now.getMonth().equals(Month.DECEMBER))
-			&& (showStartMonth.equals(Month.JANUARY) || showStartMonth.equals(Month.FEBRUARY))) {
-			showYear += 1;
-		}
+		Month month = Month.of(showStartMonthDay.get(0));
+		Integer dayOfMonth = showStartMonthDay.get(1);
 
-		// 오늘이 1월이고, 공연 날짜가 12월이면 공연의 연도를 작년으로 설정.
-		if (now.getMonth().equals(Month.JANUARY) && showStartMonth.equals(Month.DECEMBER)) {
-			showYear -= 1;
-		}
-
-		return LocalDate.of(showYear, showStartMonth, showStartDay);
+		return CustomLocalDate.of(month, dayOfMonth);
 	}
 
 	private List<RegisterShowRequest> makeRegisterShowRequest(LocalDate firstShowDate, String teams,

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
@@ -280,9 +280,9 @@ public class OcrHandler {
 	}
 
 	private List<MultipartFile> convertImageUrlToMultipartFile(List<String> imageUrls) {
-		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		List<MultipartFile> multipartFiles = new ArrayList<>();
 		for (int i = 0; i < imageUrls.size(); i++) {
+			ByteArrayOutputStream out = new ByteArrayOutputStream();
 			try {
 				BufferedImage image = ImageIO.read(new URL(imageUrls.get(i)));
 				ImageIO.write(image, "jpeg", out);

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
@@ -14,7 +14,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Month;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
@@ -32,6 +31,7 @@ import kr.codesquad.jazzmeet.global.error.CustomException;
 import kr.codesquad.jazzmeet.global.error.statuscode.ShowErrorCode;
 import kr.codesquad.jazzmeet.global.util.CustomLocalDate;
 import kr.codesquad.jazzmeet.global.util.CustomMultipartFile;
+import kr.codesquad.jazzmeet.global.util.TextParser;
 import kr.codesquad.jazzmeet.image.dto.response.ImageCreateResponse;
 import kr.codesquad.jazzmeet.image.dto.response.ImageSaveResponse;
 import kr.codesquad.jazzmeet.image.entity.ImageStatus;
@@ -180,12 +180,8 @@ public class OcrHandler {
 	}
 
 	private LocalDate makeShowStartLocalDate(String showStartEndDateText) {
-		// inferText = "12.27 - 12.31"
-		String[] showStartEndDate = showStartEndDateText.replace(" ", "").split("-");
-		List<Integer> showStartMonthDay = Arrays.stream(showStartEndDate[0].split("\\."))
-			.map(Integer::parseInt).toList();
-		Month month = Month.of(showStartMonthDay.get(0));
-		Integer dayOfMonth = showStartMonthDay.get(1);
+		Month month = TextParser.getMonth(showStartEndDateText);
+		Integer dayOfMonth = TextParser.getDayOfMonth(showStartEndDateText);
 
 		return CustomLocalDate.of(month, dayOfMonth);
 	}

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
@@ -38,6 +38,7 @@ import kr.codesquad.jazzmeet.image.entity.ImageStatus;
 import kr.codesquad.jazzmeet.image.repository.S3ImageHandler;
 import kr.codesquad.jazzmeet.image.service.ImageService;
 import kr.codesquad.jazzmeet.show.dto.request.RegisterShowRequest;
+import kr.codesquad.jazzmeet.show.mapper.ShowMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -208,14 +209,10 @@ public class OcrHandler {
 			Long posterId = posterIds.get(i / 2);
 
 			if (isSatFirstShow) { // 토요일만 스케줄이 다르다.
-				LocalDateTime specialShowStartTime = LocalDateTime.of(showDate, ENTRY55_START_TIME_SAT_SPECIAL);
-				LocalDateTime specialShowEndTime = specialShowStartTime.plusMinutes(ENTRY55_RUNTIME);
-				RegisterShowRequest request = RegisterShowRequest.builder()
-					.teamName(teamName)
-					.description(teamMusician)
-					.posterId(posterId)
-					.startTime(specialShowStartTime)
-					.endTime(specialShowEndTime).build();
+				LocalDateTime saturdayShowStartTime = LocalDateTime.of(showDate, ENTRY55_START_TIME_SAT_SPECIAL);
+				LocalDateTime saturdayShowEndTime = saturdayShowStartTime.plusMinutes(ENTRY55_RUNTIME);
+				RegisterShowRequest request = ShowMapper.INSTANCE.toRegisterShowRequest(teamName, teamMusician,
+					posterId, saturdayShowStartTime, saturdayShowEndTime);
 				requests.add(request);
 				// 첫번째 공연 플래그 변경
 				isSatFirstShow = false;
@@ -227,20 +224,10 @@ public class OcrHandler {
 			LocalDateTime secondShowStartTime = LocalDateTime.of(showDate, ENTRY55_START_TIME_2ND);
 			LocalDateTime secondShowEndTime = secondShowStartTime.plusMinutes(ENTRY55_RUNTIME);
 
-			RegisterShowRequest firstShowRequest = RegisterShowRequest.builder()
-				.teamName(teamName)
-				.description(teamMusician)
-				.posterId(posterId)
-				.startTime(firstShowStartTime)
-				.endTime(firstShowEndTime)
-				.build();
-			RegisterShowRequest secondShowRequest = RegisterShowRequest.builder()
-				.teamName(teamName)
-				.description(teamMusician)
-				.posterId(posterId)
-				.startTime(secondShowStartTime)
-				.endTime(secondShowEndTime)
-				.build();
+			RegisterShowRequest firstShowRequest = ShowMapper.INSTANCE.toRegisterShowRequest(teamName, teamMusician,
+				posterId, firstShowStartTime, firstShowEndTime);
+			RegisterShowRequest secondShowRequest = ShowMapper.INSTANCE.toRegisterShowRequest(teamName, teamMusician,
+				posterId, secondShowStartTime, secondShowEndTime);
 
 			requests.add(firstShowRequest);
 			requests.add(secondShowRequest);

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
@@ -1,0 +1,232 @@
+package kr.codesquad.jazzmeet.show.repository;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.codesquad.jazzmeet.global.error.CustomException;
+import kr.codesquad.jazzmeet.global.error.statuscode.ShowErrorCode;
+import kr.codesquad.jazzmeet.show.dto.request.RegisterShowRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OcrHandler {
+
+	public static final String SHOW_DATE = "Show Date";
+	public static final String NAME = "name";
+	public static final String TEAMS = "Teams";
+	public static final String INFER_TEXT = "inferText";
+	private static final String SCHEDULE = "스케줄";
+	private static final LocalTime ENTRY55_START_TIME_1ST = LocalTime.of(7, 30);
+	private static final LocalTime ENTRY55_START_TIME_2ND = LocalTime.of(9, 40);
+	private static final LocalTime ENTRY55_START_TIME_SAT_SPECIAL = LocalTime.of(4, 20);
+	private static final int ENTRY55_RUNTIME = 55;
+
+	@Value("${naver.clova.endpoint}")
+	private String apiURL;
+	@Value("${naver.clova.secretKey}")
+	private String secretKey;
+
+	@Transactional
+	public List<RegisterShowRequest> getShows(String venueName, String imageUrl, LocalDate latestShowDate) {
+		StringBuffer response = sendRequest(imageUrl);
+		List<RegisterShowRequest> requests = toRegisterShowRequest(venueName, response, latestShowDate);
+		if (requests.isEmpty()) {
+			throw new CustomException(ShowErrorCode.OBJECT_TRANSFORMATION_FAILD);
+		}
+
+		return requests;
+	}
+
+	private StringBuffer sendRequest(String imageUrl) {
+		try {
+			URL url = new URL(apiURL);
+			HttpURLConnection con = (HttpURLConnection)url.openConnection();
+			con.setUseCaches(false);
+			con.setDoInput(true);
+			con.setDoOutput(true);
+			con.setRequestMethod("POST");
+			con.setRequestProperty("Content-Type", "application/json; charset=utf-8");
+			con.setRequestProperty("X-OCR-SECRET", secretKey);
+
+			JSONObject json = new JSONObject();
+			json.put("version", "V2");
+			json.put("requestId", UUID.randomUUID().toString());
+			json.put("timestamp", System.currentTimeMillis());
+			JSONObject image = new JSONObject();
+			image.put("format", "jpg");
+			image.put("url", imageUrl); // image should be public, otherwise, should use data
+			image.put("name", "demo");
+			JSONArray images = new JSONArray();
+			images.put(image);
+			json.put("images", images);
+			String postParams = json.toString();
+
+			DataOutputStream wr = new DataOutputStream(con.getOutputStream());
+			wr.writeBytes(postParams);
+			wr.flush();
+			wr.close();
+
+			int responseCode = con.getResponseCode();
+			BufferedReader br;
+			if (responseCode == 200) {
+				br = new BufferedReader(new InputStreamReader(con.getInputStream()));
+			} else {
+				br = new BufferedReader(new InputStreamReader(con.getErrorStream()));
+			}
+			String inputLine;
+			StringBuffer response = new StringBuffer();
+			while ((inputLine = br.readLine()) != null) {
+				response.append(inputLine);
+			}
+			br.close();
+
+			log.debug("OCR Response: {}", response);
+			return response;
+		} catch (Exception e) {
+			throw new CustomException(ShowErrorCode.OCR_REQUEST_FAILED);
+		}
+	}
+
+	private List<RegisterShowRequest> toRegisterShowRequest(String venueName, StringBuffer response,
+		LocalDate latestShowDate) {
+		// JSON 파싱
+		JSONTokener tokener = new JSONTokener(response.toString());
+		JSONObject object = new JSONObject(tokener);
+		JSONObject images = object.getJSONArray("images").getJSONObject(0);
+		// 일치하지 않는 공연장 템플릿(OCR)이 적용되었으면 에러를 반환한다.
+		String templateName = images.getJSONObject("matchedTemplate").get(NAME).toString();
+		String venueNameSchedule = venueName + " " + SCHEDULE;
+		if (!templateName.equals(venueNameSchedule)) {
+			throw new CustomException(ShowErrorCode.OCR_NOT_MATCHED_VENUE_AND_IMAGE);
+		}
+		JSONArray fields = images.getJSONArray("fields");
+		LocalDate firstShowDate = null;
+		// 아티스트의 이름, 상세(=연주자들)
+		String teamsText = null;
+		// response로 받은 공연 데이터가 최신 데이터인지 확인하는 flag
+		boolean isShowDataAfterLatestShow = false;
+		for (int i = 0; i < fields.length(); i++) {
+			JSONObject jsonObject = fields.getJSONObject(i);
+			// 처음 공연 날짜 , 마지막 공연 날짜
+			if (jsonObject.get(NAME).equals(SHOW_DATE)) {
+				String showFirstLastDateText = jsonObject.get(INFER_TEXT).toString();
+				firstShowDate = makeShowStartLocalDate(showFirstLastDateText);
+				// response로 받은 공연 시작 날짜가, 공연장에 등록 된 가장 최신 공연 날짜보다 뒤라면
+				if (latestShowDate == null || firstShowDate.isAfter(latestShowDate)) {
+					// 최신 데이터로 flag 변경.
+					isShowDataAfterLatestShow = true;
+				}
+			}
+
+			// 아티스트 목록
+			if (jsonObject.get(NAME).equals(TEAMS)) {
+				teamsText = jsonObject.get(INFER_TEXT).toString();
+			}
+		}
+
+		if (firstShowDate == null) {
+			throw new CustomException(ShowErrorCode.OCR_EXTRACTION_FAILED_SHOW_DATE);
+		}
+
+		if (teamsText == null) {
+			throw new CustomException(ShowErrorCode.OCR_EXTRACTION_FAILED_ARTISTS_AND_DETAILS);
+		}
+
+		if (!isShowDataAfterLatestShow) {
+			throw new CustomException(ShowErrorCode.OCR_NOT_LATEST_SHOW);
+		}
+
+		// response가 최신 데이터라면 파싱해서 공연 등록 request로 만든다.
+		return makeRegisterShowRequest(firstShowDate, teamsText);
+	}
+
+	private LocalDate makeShowStartLocalDate(String showStartEndDateText) {
+		// inferText = "12.27 - 12.31"
+		String[] showStartEndDate = showStartEndDateText.replace(" ", "").split("-");
+		List<Integer> showStartMonthDay = Arrays.stream(showStartEndDate[0].split("\\."))
+			.map(Integer::parseInt).toList();
+		Month showStartMonth = Month.of(showStartMonthDay.get(0));
+		Integer showStartDay = showStartMonthDay.get(1);
+		LocalDate now = LocalDate.now();
+		int showYear = now.getYear();
+		// 오늘이 11월이나 12월이고, 공연 날짜가 1월이나 2월이면 공연의 연도를 내년으로 설정.
+		if ((now.getMonth().equals(Month.NOVEMBER) || now.getMonth().equals(Month.DECEMBER))
+			&& (showStartMonth.equals(Month.JANUARY) || showStartMonth.equals(Month.FEBRUARY))) {
+			showYear += 1;
+		}
+
+		return LocalDate.of(showYear, showStartMonth, showStartDay);
+	}
+
+	private List<RegisterShowRequest> makeRegisterShowRequest(LocalDate firstShowDate, String teams) {
+		List<RegisterShowRequest> requests = new ArrayList<>();
+		String[] splitedArtists = teams.split("\n");
+		LocalDate showDate = firstShowDate;
+
+		for (int i = 0; i < splitedArtists.length; i += 2) {
+			String teamName = splitedArtists[i];
+			String teamMusician = splitedArtists[i + 1];
+
+			if (showDate.getDayOfWeek().equals(DayOfWeek.SATURDAY)) { // 토요일만 스케줄이 다르다.
+				LocalDateTime specialShowStartTime = LocalDateTime.of(showDate, ENTRY55_START_TIME_SAT_SPECIAL);
+				LocalDateTime specialShowEndTime = specialShowStartTime.minusMinutes(ENTRY55_RUNTIME);
+				RegisterShowRequest request = RegisterShowRequest.builder()
+					.teamName(teamName)
+					.description(teamMusician)
+					.startTime(specialShowStartTime)
+					.endTime(specialShowEndTime).build();
+				requests.add(request);
+				continue;
+			}
+
+			LocalDateTime firstShowStartTime = LocalDateTime.of(showDate, ENTRY55_START_TIME_1ST);
+			LocalDateTime firstShowEndTime = firstShowStartTime.plusMinutes(ENTRY55_RUNTIME);
+			LocalDateTime secondShowStartTime = LocalDateTime.of(showDate, ENTRY55_START_TIME_2ND);
+			LocalDateTime secondShowEndTime = secondShowStartTime.plusMinutes(ENTRY55_RUNTIME);
+
+			RegisterShowRequest firstShowRequest = RegisterShowRequest.builder()
+				.teamName(teamName)
+				.description(teamMusician)
+				.startTime(firstShowStartTime)
+				.endTime(firstShowEndTime)
+				.build();
+			RegisterShowRequest secondShowRequest = RegisterShowRequest.builder()
+				.teamName(teamName)
+				.description(teamMusician)
+				.startTime(secondShowStartTime)
+				.endTime(secondShowEndTime)
+				.build();
+
+			requests.add(firstShowRequest);
+			requests.add(secondShowRequest);
+
+			// 다음 날로 변경
+			showDate = showDate.plusDays(1);
+		}
+
+		return requests;
+	}
+
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/ShowRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/ShowRepository.java
@@ -23,4 +23,7 @@ public interface ShowRepository extends JpaRepository<Show, Long> {
 
 	@Query("select s from Show s join fetch s.venue join fetch s.poster where s.id = :showId")
 	Optional<Show> findEntireShowById(@Param("showId") Long showId);
+
+	@Query("select s from Show s where s.startTime = (select MAX(s2.startTime) from Show s2) and s.venue.id = :venueId")
+	Optional<Show> findLatestShowByVenueId(Long venueId);
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
@@ -47,16 +47,16 @@ public class WebCrawler {
 			showImageUrls = getImageUrl(driver, venueInstagramUrl, latestShowDate);
 		} catch (InterruptedException e) {
 			throw new CustomException(ShowErrorCode.CRAWLING_REQUEST_FAILED);
+		} finally {
+			//드라이버 연결 종료
+			driver.close(); //드라이버 연결 해제
+			//프로세스 종료
+			driver.quit();
 		}
 
 		if (showImageUrls.isEmpty()) {
 			throw new CustomException(ShowErrorCode.NOT_FOUND_SHOW_IMAGE_URL);
 		}
-
-		//드라이버 연결 종료
-		driver.close(); //드라이버 연결 해제
-		//프로세스 종료
-		driver.quit();
 
 		return showImageUrls;
 	}

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
@@ -19,6 +19,7 @@ import org.springframework.util.ObjectUtils;
 
 import kr.codesquad.jazzmeet.global.error.CustomException;
 import kr.codesquad.jazzmeet.global.error.statuscode.ShowErrorCode;
+import kr.codesquad.jazzmeet.global.util.CustomLocalDate;
 import kr.codesquad.jazzmeet.global.util.WebDriverUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -184,22 +185,14 @@ public class WebCrawler {
 			return true;
 		}
 
-		LocalDate now = LocalDate.now();
 		// articleText.replace(" ", "").split("-")[0] = "12.28"
-		List<Integer> showStartMonthDay = Arrays.stream(articleText.replace(" ", "").split("-")[0].split("\\."))
+		String[] showStartEndDate = articleText.replace(" ", "").split("-");
+		List<Integer> showStartMonthDay = Arrays.stream(showStartEndDate[0].split("\\."))
 			.map(Integer::parseInt).toList();
-		// 추출해 온 공연 날짜를 LocalDate 형식으로 만들기
-		Month showStartMonth = Month.of(showStartMonthDay.get(0));
-		Integer showStartDay = showStartMonthDay.get(1);
-		int showYear = now.getYear();
+		Month month = Month.of(showStartMonthDay.get(0));
+		Integer dayOfMonth = showStartMonthDay.get(1);
 
-		// 오늘이 11월이나 12월이고, (추출해 온) 공연 날짜가 1월이나 2월이면 공연의 연도를 내년으로 설정.
-		if ((now.getMonth().equals(Month.NOVEMBER) || now.getMonth().equals(Month.DECEMBER))
-			&& (showStartMonth.equals(Month.JANUARY) || showStartMonth.equals(Month.FEBRUARY))) {
-			showYear += 1;
-		}
-
-		LocalDate showDate = LocalDate.of(showYear, showStartMonth, showStartDay);
+		LocalDate showDate = CustomLocalDate.of(month, dayOfMonth);
 
 		return showDate.isAfter(latestShowDate);
 	}

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
@@ -36,7 +36,7 @@ public class WebCrawler {
 	@Value("${instagram.password}")
 	private String instagramPassword;
 
-	public List<String> getShowImageUrl(String venueInstagramUrl, LocalDate latestShowDate) {
+	public List<String> getShowImageUrls(String venueInstagramUrl, LocalDate latestShowDate) {
 		List<String> showImageUrls = null;
 		WebDriver driver = WebDriverUtil.getChromeDriver();
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
@@ -185,8 +185,8 @@ public class WebCrawler {
 		}
 
 		LocalDate now = LocalDate.now();
-		// articleText.split(" ")[0] = "12.28"
-		List<Integer> showStartMonthDay = Arrays.stream(articleText.split(" ")[0].split("."))
+		// articleText.replace(" ", "").split("-")[0] = "12.28"
+		List<Integer> showStartMonthDay = Arrays.stream(articleText.replace(" ", "").split("-")[0].split("\\."))
 			.map(Integer::parseInt).toList();
 		// 추출해 온 공연 날짜를 LocalDate 형식으로 만들기
 		Month showStartMonth = Month.of(showStartMonthDay.get(0));

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
@@ -20,6 +19,7 @@ import org.springframework.util.ObjectUtils;
 import kr.codesquad.jazzmeet.global.error.CustomException;
 import kr.codesquad.jazzmeet.global.error.statuscode.ShowErrorCode;
 import kr.codesquad.jazzmeet.global.util.CustomLocalDate;
+import kr.codesquad.jazzmeet.global.util.TextParser;
 import kr.codesquad.jazzmeet.global.util.WebDriverUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -185,13 +185,8 @@ public class WebCrawler {
 			return true;
 		}
 
-		// articleText.replace(" ", "").split("-")[0] = "12.28"
-		String[] showStartEndDate = articleText.replace(" ", "").split("-");
-		List<Integer> showStartMonthDay = Arrays.stream(showStartEndDate[0].split("\\."))
-			.map(Integer::parseInt).toList();
-		Month month = Month.of(showStartMonthDay.get(0));
-		Integer dayOfMonth = showStartMonthDay.get(1);
-
+		Month month = TextParser.getMonth(articleText);
+		Integer dayOfMonth = TextParser.getDayOfMonth(articleText);
 		LocalDate showDate = CustomLocalDate.of(month, dayOfMonth);
 
 		return showDate.isAfter(latestShowDate);

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
@@ -30,7 +30,7 @@ public class WebCrawler {
 
 	private static final String NEXT_ARTICLE_BUTTON_CLASS_NAME = "_abl-";
 	public static final String NEXT_PHOTO_BUTTON_CLASS_NAME = "_9zm2";
-	public static final int MAX_FIXED_ARTICLE_NUMBER = 1;
+	public static final int MAX_FIXED_ARTICLE_NUMBER = 3;
 
 	@Value("${instagram.id}")
 	private String instagramId;
@@ -126,9 +126,9 @@ public class WebCrawler {
 				driver.findElements(By.className(NEXT_PHOTO_BUTTON_CLASS_NAME))
 					.get(0)
 					.click();
-				// driver.findElements(By.className(NEXT_PHOTO_BUTTON_CLASS_NAME))
-				// 	.get(0)
-				// 	.click();
+				driver.findElements(By.className(NEXT_PHOTO_BUTTON_CLASS_NAME))
+					.get(0)
+					.click();
 				Thread.sleep(2000); // 대기 시간
 
 				// 1,2,3번 이미지는 "_aagu _aato"(3번은 스케줄), 4,5번 이미지는 "_aagu _aa20 _aato", 6,7번 이미지는 ...

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
@@ -1,0 +1,172 @@
+package kr.codesquad.jazzmeet.show.repository;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+
+import kr.codesquad.jazzmeet.global.error.CustomException;
+import kr.codesquad.jazzmeet.global.error.statuscode.ShowErrorCode;
+import kr.codesquad.jazzmeet.global.util.WebDriverUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@RequiredArgsConstructor
+@Component
+public class WebCrawler {
+
+	private static final String NEXT_ARTICLE_BUTTON_CLASS_NAME = "_abl-";
+	public static final String NEXT_PHOTO_BUTTON_CLASS_NAME = "_9zm2";
+	public static final int MAX_FIXED_ARTICLE_NUMBER = 2;
+
+	@Value("${instagram.id}")
+	private String instagramId;
+	@Value("${instagram.password}")
+	private String instagramPassword;
+
+	public List<String> getShowImageUrl(String venueInstagramUrl, LocalDate latestShowDate) {
+		List<String> showImageUrls = null;
+		WebDriver driver = WebDriverUtil.getChromeDriver();
+
+		try {
+			showImageUrls = getImageUrl(driver, venueInstagramUrl, latestShowDate);
+		} catch (InterruptedException e) {
+			throw new CustomException(ShowErrorCode.CRAWLING_REQUEST_FAILED);
+		}
+
+		if (showImageUrls.isEmpty()) {
+			throw new CustomException(ShowErrorCode.NOT_FOUND_SHOW_IMAGE_URL);
+		}
+
+		//드라이버 연결 종료
+		driver.close(); //드라이버 연결 해제
+		//프로세스 종료
+		driver.quit();
+
+		return showImageUrls;
+	}
+
+	private List<String> getImageUrl(WebDriver driver, String venueInstagramUrl, LocalDate latestShowDate) throws
+		InterruptedException {
+		// 대기 시간 지정하기
+		WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+		List<String> imageUrls = new ArrayList<>();
+
+		if (!ObjectUtils.isEmpty(driver)) {
+			// url로 이동
+			driver.get("https://www.instagram.com/");
+			// 이동 시 생기는 브라우저 로드 시간을 기다린다.
+			driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
+
+			// 로그인
+			driver.findElements(
+					By.cssSelector("#loginForm > div > div:nth-child(1) > div > label > input"))
+				.get(0).sendKeys(instagramId);
+			driver.findElements(
+					By.cssSelector("#loginForm > div > div:nth-child(2) > div > label > input"))
+				.get(0).sendKeys(instagramPassword);
+			driver.findElements(
+					By.cssSelector("#loginForm > div > div:nth-child(3) > button > div"))
+				.get(0).click();
+			driver.manage()
+				.timeouts()
+				.implicitlyWait(Duration.ofSeconds(5)); // 암묵적 대기. 지정한 시간보다 일찍 로드되면 바로 다음 작업으로 넘어간다.
+
+			wait.until(ExpectedConditions.urlToBe(
+				"https://www.instagram.com/accounts/onetap/?next=%2F")); // 로그인 완료 후 url 전환하기까지 대기
+			driver.get(venueInstagramUrl); // 공연장 instagram url로 이동
+
+			driver.findElements(
+					By.className("_aagw")) // 게시물 선택
+				.get(0).click();
+
+			Thread.sleep(2000); // 대기 시간
+
+			for (int i = 0; i < MAX_FIXED_ARTICLE_NUMBER; i++) { // 맨 위에 고정된 게시물 3개
+				int nextBtnIndex = 1;
+				if (i == 0) {
+					nextBtnIndex = 0;
+				}
+				// 게시물 설명 텍스트
+				String articleText = driver.findElements(
+						By.className("_a9zs"))
+					.get(0).getText();
+				if (!articleText.contains("라인업")) { // 스케줄 키워드가 포함되어있지 않으면 다음 게시물을 탐색한다.
+					driver.findElements(By.className(NEXT_ARTICLE_BUTTON_CLASS_NAME))
+						.get(nextBtnIndex)
+						.click(); // 오른쪽 화살표 클릭
+					continue;
+				}
+				// DB에 저장되어있던 가장 최근 공연과 비교해, 크롤링 한 공연 날짜가 새로운 공연이 아니면 다음 게시물을 탐색한다.
+				if (!isNewShowDate(articleText, latestShowDate)) {
+					driver.findElements(By.className(NEXT_ARTICLE_BUTTON_CLASS_NAME))
+						.get(nextBtnIndex)
+						.click();
+					continue;
+				}
+
+				// 오른쪽 화살표로 img 탐색.
+				// TODO: 1월 둘째주부터 변경 2번째 -> 3번째로 변경.
+				// entry55인 경우 3번째 img가 주간 공연 스케줄, 4번째부터 공연 poster가 나열된다.
+				driver.findElements(By.className(NEXT_PHOTO_BUTTON_CLASS_NAME))
+					.get(0)
+					.click();
+				// driver.findElements(By.className(NEXT_PHOTO_BUTTON_CLASS_NAME))
+				// 	.get(0)
+				// 	.click();
+				Thread.sleep(2000); // 대기 시간
+
+				// 1,2,3번 이미지는 "_aagu _aato"(3번은 스케줄), 4,5번 이미지는 "_aagu _aa20 _aato", 6,7번 이미지는 ...
+				WebElement img = driver.findElements(
+					By.cssSelector("div._aagu._aato > div > img")).get(1); // 이미지 선택
+				String imageUrl = img.getAttribute("src");
+				log.debug("Instagram Image URL: {}", imageUrl);
+				// TODO: 공연 포스터 크롤링하기
+				imageUrls.add(imageUrl);
+
+				driver.findElements(By.className(NEXT_ARTICLE_BUTTON_CLASS_NAME))
+					.get(nextBtnIndex)
+					.click();
+			}
+		}
+
+		return imageUrls;
+	}
+
+	private boolean isNewShowDate(String articleText, LocalDate latestShowDate) {
+		if (latestShowDate == null) { // 저장된 공연이 없으므로 크롤링한 공연은 무조건 최신이다.
+			return true;
+		}
+
+		LocalDate now = LocalDate.now();
+		// articleText.split(" ")[0] = "12.28"
+		List<Integer> showStartMonthDay = Arrays.stream(articleText.split(" ")[0].split("."))
+			.map(Integer::parseInt).toList();
+		// 추출해 온 공연 날짜를 LocalDate 형식으로 만들기
+		Month showStartMonth = Month.of(showStartMonthDay.get(0));
+		Integer showStartDay = showStartMonthDay.get(1);
+		int showYear = now.getYear();
+
+		// 오늘이 11월이나 12월이고, (추출해 온) 공연 날짜가 1월이나 2월이면 공연의 연도를 내년으로 설정.
+		if ((now.getMonth().equals(Month.NOVEMBER) || now.getMonth().equals(Month.DECEMBER))
+			&& (showStartMonth.equals(Month.JANUARY) || showStartMonth.equals(Month.FEBRUARY))) {
+			showYear += 1;
+		}
+
+		LocalDate showDate = LocalDate.of(showYear, showStartMonth, showStartDay);
+
+		return showDate.isAfter(latestShowDate);
+	}
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowScheduler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowScheduler.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +28,11 @@ public class ShowScheduler {
 	private final OcrHandler ocrHandler;
 	private final WebCrawler crawler;
 
+	/**
+	 * Cron 표현식을 사용한 작업 예약
+	 * 초(0-59) 분(0-59) 시간(0-23) 일(1-31) 월(1-12) 요일(0-7)
+	 */
+	@Scheduled(cron = "0 0 4 ? * SAT")    // 매주 토요일 오전 4시 00분 00초
 	@Transactional
 	public void autoInsertShowSchedule() {
 		// 	// TODO: 모든 공연장에 대한 인스타그램 링크를 가져온다.

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowScheduler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowScheduler.java
@@ -1,0 +1,56 @@
+package kr.codesquad.jazzmeet.show.service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.codesquad.jazzmeet.show.dto.request.RegisterShowRequest;
+import kr.codesquad.jazzmeet.show.repository.OcrHandler;
+import kr.codesquad.jazzmeet.show.repository.WebCrawler;
+import kr.codesquad.jazzmeet.venue.entity.Venue;
+import kr.codesquad.jazzmeet.venue.service.VenueService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@RequiredArgsConstructor
+@Component
+public class ShowScheduler {
+	public static final String ENTRY55 = "entry55";
+	public static final String ENTRY55_INSTAGRAM_URL = "https://www.instagram.com/entry55_official/";
+
+	private final ShowService showService;
+	private final VenueService venueService;
+	private final OcrHandler ocrHandler;
+	private final WebCrawler crawler;
+
+	@Transactional
+	public void autoInsertShowSchedule() {
+		// 	// TODO: 모든 공연장에 대한 인스타그램 링크를 가져온다.
+		// 	List<Link> venueLinks = venueService.findAllByLinkTypeEqualsInstagram();
+		// 	for (Link link : venueLinks) {
+		// 	}
+		Venue venue = venueService.findByName(ENTRY55);
+		String venueInstagramUrl = ENTRY55_INSTAGRAM_URL;
+
+		// 공연장에 저장 된 최신 공연을 가져온다.
+		LocalDate latestShowDate = showService.getLatestShowBy(venue.getId())
+			.map(show -> show.getStartTime().toLocalDate())
+			.orElse(null);
+
+		// 1. 인스타그램에서 (공연 스케줄이 담겨있는) 이미지 url을 크롤링 해 온다.
+		List<String> showImageUrls = crawler.getShowImageUrl(venueInstagramUrl, latestShowDate);
+
+		for (String showImageUrl : showImageUrls) {
+			// 2. 네이버 ocr에 텍스트 추출 요청을 보내고 response를 파싱해 공연 등록 request로 만든다.
+			List<RegisterShowRequest> requests = ocrHandler.getShows(venue.getName(), showImageUrl, latestShowDate);
+			// 3. DB에 새로운 공연을 넣는다.
+			for (RegisterShowRequest request : requests) {
+				showService.registerShow(venue.getId(), request);
+			}
+		}
+	}
+
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowScheduler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowScheduler.java
@@ -1,6 +1,7 @@
 package kr.codesquad.jazzmeet.show.service;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
 
 import org.springframework.stereotype.Component;
@@ -41,11 +42,12 @@ public class ShowScheduler {
 			.orElse(null);
 
 		// 1. 인스타그램에서 (공연 스케줄이 담겨있는) 이미지 url을 크롤링 해 온다.
-		List<String> showImageUrls = crawler.getShowImageUrls(venueInstagramUrl, latestShowDate);
+		HashMap<String, List<String>> showImageUrls = crawler.getShowImageUrls(venueInstagramUrl, latestShowDate);
 
-		for (String showImageUrl : showImageUrls) {
+		for (String showImageUrl : showImageUrls.keySet()) {
 			// 2. 네이버 ocr에 텍스트 추출 요청을 보내고 response를 파싱해 공연 등록 request로 만든다.
-			List<RegisterShowRequest> requests = ocrHandler.getShows(venue.getName(), showImageUrl, latestShowDate);
+			List<RegisterShowRequest> requests = ocrHandler.getShows(venue.getName(), showImageUrl,
+				showImageUrls.get(showImageUrl), latestShowDate);
 			// 3. DB에 새로운 공연을 넣는다.
 			for (RegisterShowRequest request : requests) {
 				showService.registerShow(venue.getId(), request);

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowScheduler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowScheduler.java
@@ -41,7 +41,7 @@ public class ShowScheduler {
 			.orElse(null);
 
 		// 1. 인스타그램에서 (공연 스케줄이 담겨있는) 이미지 url을 크롤링 해 온다.
-		List<String> showImageUrls = crawler.getShowImageUrl(venueInstagramUrl, latestShowDate);
+		List<String> showImageUrls = crawler.getShowImageUrls(venueInstagramUrl, latestShowDate);
 
 		for (String showImageUrl : showImageUrls) {
 			// 2. 네이버 ocr에 텍스트 추출 요청을 보내고 response를 파싱해 공연 등록 request로 만든다.

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowService.java
@@ -7,6 +7,7 @@ import java.time.format.DateTimeParseException;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
@@ -137,7 +138,11 @@ public class ShowService {
 	@Transactional
 	public RegisterShowResponse registerShow(Long venueId, RegisterShowRequest registerShowRequest) {
 		Venue venue = venueService.findById(venueId);
-		Image poster = imageService.findById(registerShowRequest.posterId());
+		Long posterId = registerShowRequest.posterId();
+		Image poster = null;
+		if (posterId != null) {
+			poster = imageService.findById(posterId);
+		}
 		Show show = ShowMapper.INSTANCE.toShow(registerShowRequest, venue, poster);
 
 		Show savedShow = showRepository.save(show);
@@ -162,5 +167,9 @@ public class ShowService {
 
 		show.deletePoster();
 		showRepository.delete(show);
+	}
+
+	public Optional<Show> getLatestShowBy(Long venueId) {
+		return showRepository.findLatestShowByVenueId(venueId);
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/Link.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/entity/Link.java
@@ -10,8 +10,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Link {

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/LinkRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/LinkRepository.java
@@ -1,0 +1,12 @@
+package kr.codesquad.jazzmeet.venue.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.codesquad.jazzmeet.venue.entity.Link;
+import kr.codesquad.jazzmeet.venue.entity.LinkType;
+
+public interface LinkRepository extends JpaRepository<Link, Long> {
+	List<Link> findByVenueIsNotNullAndLinkType(LinkType linkType);
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/VenueRepository.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/repository/VenueRepository.java
@@ -1,6 +1,7 @@
 package kr.codesquad.jazzmeet.venue.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,4 +12,6 @@ import kr.codesquad.jazzmeet.venue.entity.Venue;
 public interface VenueRepository extends JpaRepository<Venue, Long> {
 
 	List<Venue> findTop10ByNameContainingOrRoadNameAddressContaining(String nameWord, String roadNameAddressWord);
+
+	Optional<Venue> findByName(String name);
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/service/VenueService.java
@@ -20,8 +20,12 @@ import kr.codesquad.jazzmeet.venue.dto.response.VenueDetailResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueListResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenuePinsResponse;
 import kr.codesquad.jazzmeet.venue.dto.response.VenueSearchResponse;
+import kr.codesquad.jazzmeet.venue.entity.Link;
+import kr.codesquad.jazzmeet.venue.entity.LinkType;
 import kr.codesquad.jazzmeet.venue.entity.Venue;
 import kr.codesquad.jazzmeet.venue.mapper.VenueMapper;
+import kr.codesquad.jazzmeet.venue.repository.LinkRepository;
+import kr.codesquad.jazzmeet.venue.repository.LinkTypeRepository;
 import kr.codesquad.jazzmeet.venue.repository.VenueQueryRepository;
 import kr.codesquad.jazzmeet.venue.repository.VenueRepository;
 import kr.codesquad.jazzmeet.venue.util.LocationUtil;
@@ -38,9 +42,12 @@ public class VenueService {
 	private static final int PAGE_NUMBER_OFFSET = 1; // 페이지를 1부터 시작하게 하기 위한 offset
 	private static final int PAGE_SIZE = 10;
 	private static final int ADMIN_PAGE_SIZE = 20;
+	public static final String LINK_TYPE_NAME_INSTAGRAM = "instagram";
 
 	private final VenueRepository venueRepository;
 	private final VenueQueryRepository venueQueryRepository;
+	private final LinkRepository linkRepository;
+	private final LinkTypeRepository linkTypeRepository;
 
 	public List<VenueAutocompleteResponse> searchAutocompleteList(String word) {
 		// word가 "" 이면 공연장 목록 전부 조회
@@ -100,7 +107,8 @@ public class VenueService {
 		LocalDate curDate = LocalDate.now();
 		Page<VenueSearchData> venuesByLocation = venueQueryRepository.findVenuesByLocation(range, pageRequest, curDate);
 
-		return VenueMapper.INSTANCE.toVenueSearchResponse(venuesByLocation, venuesByLocation.getNumber() + PAGE_NUMBER_OFFSET);
+		return VenueMapper.INSTANCE.toVenueSearchResponse(venuesByLocation,
+			venuesByLocation.getNumber() + PAGE_NUMBER_OFFSET);
 	}
 
 	public Venue findById(Long venueId) {
@@ -153,5 +161,16 @@ public class VenueService {
 	@Transactional
 	public void deleteById(Long venueId) {
 		venueRepository.deleteById(venueId);
+	}
+
+	public List<Link> findAllByLinkTypeEqualsInstagram() {
+		LinkType linkType = linkTypeRepository.findByName(LINK_TYPE_NAME_INSTAGRAM)
+			.orElseThrow(() -> new CustomException(VenueErrorCode.NOT_FOUND_LINK_TYPE));
+		return linkRepository.findByVenueIsNotNullAndLinkType(linkType);
+	}
+
+	public Venue findByName(String venueName) {
+		return venueRepository.findByName(venueName)
+			.orElseThrow(() -> new CustomException(VenueErrorCode.NOT_FOUND_VENUE));
 	}
 }

--- a/be/src/test/java/kr/codesquad/jazzmeet/image/service/ImageServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/image/service/ImageServiceTest.java
@@ -35,9 +35,10 @@ class ImageServiceTest extends IntegrationTestSupport {
 	void saveImages() {
 		// given
 		List<String> imageUrls = List.of("imgUrl1", "imgUrl2", "imgUrl3");
+		ImageStatus imageStatus = ImageStatus.UNREGISTERED;
 
 		// when
-		ImageCreateResponse imageCreateResponse = imageService.saveImages(imageUrls);
+		ImageCreateResponse imageCreateResponse = imageService.saveImages(imageUrls, imageStatus);
 
 		// then
 		assertThat(imageCreateResponse.images()).hasSize(imageUrls.size());


### PR DESCRIPTION
## What is this PR? 👓
- https://github.com/jazz-meet/jazz-meet/issues/273

## Key changes 🔑
1.  인스타에서 데이터 크롤링해서 공연 스케줄이 담긴 이미지 url 추출하기
2.  이미지 url에서 텍스트 추출하기 (네이버 클로바 OCR 이용)
3.  텍스트 파싱해서 원하는 공연 데이터로 다듬기 (RequestDto)
4. 크롤링한 포스터 url -> 파일 -> 이미지s3에 저장 -> 공연 포스터 등록
5.  `@Schedule` 적용해서 원하는 시간에 자동으로 공연 데이터를 넣도록 설정하기

## To reviewers 👋
- 기존에 있던 로직 재사용을 위해서 showService, imageService의 메서드를 약간씩 수정했습니다.
- ec2에 크롬, 크롬 드라이버 설치를 해야하고, ec2위에서도 잘 동작하는지 확인해 볼 예정입니다.
- 테스트 코드는 아직 작성하지 못했습니다.
