### PR TITLE
사용자 줌 이벤트 시 '현 지도에서 검색' 버튼 렌더링

### DIFF
--- a/fe/user/src/pages/MapPage/Map/index.tsx
+++ b/fe/user/src/pages/MapPage/Map/index.tsx
@@ -30,14 +30,15 @@ export const Map: React.FC<Props> = ({
     const map = getInitMap();
     onMapInitialized(map);
 
-    const dragendEventListener = naver.maps.Event.addListener(
-      map,
-      'dragend',
-      showMapSearchButton,
+    const events = ['dragend', 'mousewheel', 'pinch'];
+    const eventListeners = events.map((event) =>
+      naver.maps.Event.addListener(map, event, showMapSearchButton),
     );
 
     return () => {
-      naver.maps.Event.removeListener(dragendEventListener);
+      eventListeners.forEach((eventListener) =>
+        naver.maps.Event.removeListener(eventListener),
+      );
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
## What is this PR? 👓
공연장 페이지의 지도를 줌인, 줌아웃 시켜도 현 지도에서 검색 버튼(이하 현지도 버튼)이 나타나지 않음.
서비스 자체 기능에 의해 발생하는 이벤트가 아닌 사용자가 발생시킨 이벤트에 의해 줌이 발생하면 '현 지도에서 검색' 버튼이 렌더링 되도록 이벤트를 추가 등록함.
#282 

## Key changes 🔑
- 지도 컴포넌트에 사용자 이벤트 추가 등록(mousewheel, pinch)
- mousewheel의 경우 web API에서는 deprecated지만 naver maps api에서는 여전히 사용중인 이벤트

## To reviewers 👋
- 테스트 환경이 pc 브라우저로 제한되어 pinch 이벤트를 시뮬레이션해보지는 못했습니다.(`shift` + 마우스로 할 수 있다고 하는데, 저는 드래그 이벤트만 일어났습니다)
- mousewheel 이벤트가 naver maps api 문서에 언급되지 않는 UI 이벤트라서 시간이 오래 걸렸네요. 문서화가 DX에 얼마나 중요한지 체감됩니다.
