### PR TITLE
공연장 상세의 뒤로가기 누르면 url에 물음표 추가되는 문제 수정

### DIFF
--- a/fe/user/src/pages/MapPage/Panel/VenueDetail/index.tsx
+++ b/fe/user/src/pages/MapPage/Panel/VenueDetail/index.tsx
@@ -25,7 +25,7 @@ export const VenueDetail: React.FC = () => {
   const [data, setData] = useState<VenueDetailData>();
 
   const backToVenueList = () => {
-    navigate(`/map?${currentLocation.search}`);
+    navigate(`/map${currentLocation.search}`);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## What is this PR? 👓
공연장 상세의 뒤로가기 버튼을 누를 때마다 url에 물음표가 추가되어 중첩되는 문제를 수정했습니다.

## Key changes 🔑
- VenueDetail 컴포넌트의 backToVenueList의 pathname에서 물음표(?)를 제거했습니다.

## To reviewers 👋
- route의 pathname에 location.search와 물음표가 중복되어 이벤트 발생시마다 물음표가 추가되었습니다.
