### PR TITLE
공연 페이지에서 공연장 클릭 시 해당 공연의 상세페이지에서 클릭한 날짜의 공연 목록을 보여주는 기능

### DIFF
--- a/fe/user/src/pages/ShowPage/ShowContainer/RegionCard/VenueCard.tsx
+++ b/fe/user/src/pages/ShowPage/ShowContainer/RegionCard/VenueCard.tsx
@@ -17,10 +17,6 @@ export const VenueCard: React.FC<Props> = ({ id, name, shows }) => {
     (state) => state.setShowDetailDate,
   );
 
-  const setDateOfVenueCalendar = (shows: Omit<ShowDetail, 'description'>[]) => {
-    setShowDetailDate(new Date(shows[0].startTime));
-  };
-
   const navigateToVenueDetail = () => {
     navigate(`/map/venues/${id}`);
   };
@@ -29,7 +25,7 @@ export const VenueCard: React.FC<Props> = ({ id, name, shows }) => {
     <StyledVenueCard>
       <StyledCardHeader
         onClick={() => {
-          setDateOfVenueCalendar(shows);
+          setShowDetailDate(new Date(shows[0].startTime));
           navigateToVenueDetail();
         }}
       >

--- a/fe/user/src/pages/ShowPage/ShowContainer/RegionCard/VenueCard.tsx
+++ b/fe/user/src/pages/ShowPage/ShowContainer/RegionCard/VenueCard.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 import CaretRight from '~/assets/icons/CaretRight.svg?react';
+import { useShowDetailStore } from '~/stores/useShowDetailStore';
 import { ShowDetail } from '~/types/api.types';
 import { getFormattedTimeRange } from '~/utils/dateUtils';
 
@@ -12,12 +13,26 @@ type Props = {
 
 export const VenueCard: React.FC<Props> = ({ id, name, shows }) => {
   const navigate = useNavigate();
+  const setShowDetailDate = useShowDetailStore(
+    (state) => state.setShowDetailDate,
+  );
 
-  const navigateToVenueDetail = () => navigate(`/map/venues/${id}`);
+  const setDateOfVenueCalendar = (shows: Omit<ShowDetail, 'description'>[]) => {
+    setShowDetailDate(new Date(shows[0].startTime));
+  };
+
+  const navigateToVenueDetail = () => {
+    navigate(`/map/venues/${id}`);
+  };
 
   return (
     <StyledVenueCard>
-      <StyledCardHeader onClick={navigateToVenueDetail}>
+      <StyledCardHeader
+        onClick={() => {
+          setDateOfVenueCalendar(shows);
+          navigateToVenueDetail();
+        }}
+      >
         <span>{name}</span>
         <CaretRight />
       </StyledCardHeader>


### PR DESCRIPTION
## What is this PR? 👓
공연 페이지에서 공연장을 클릭했을 때의 날짜가 공연장 상세페이지 달력 초기 렌더링 시에 선택되어 있습니다.

## Key changes 🔑
- VenueCard 클릭 이벤트 핸들러에서 setShowDetailDate 추가 호출

## To reviewers 👋
