### PR TITLE
다가오는 공연 데이터 추가, 레이아웃 업데이트

### DIFF
--- a/fe/user/.babelrc
+++ b/fe/user/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["@emotion/babel-plugin"]
+}

--- a/fe/user/package-lock.json
+++ b/fe/user/package-lock.json
@@ -8,6 +8,7 @@
       "name": "jazz-meet",
       "version": "0.0.0",
       "dependencies": {
+        "@emotion/babel-plugin": "^11.11.0",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.14.14",

--- a/fe/user/package.json
+++ b/fe/user/package.json
@@ -11,6 +11,7 @@
     "mock": "json-server --watch db.json --port 3001"
   },
   "dependencies": {
+    "@emotion/babel-plugin": "^11.11.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.14.14",

--- a/fe/user/src/pages/MainPage/MainSection/CardList/Cards/UpcomingShowCard.tsx
+++ b/fe/user/src/pages/MainPage/MainSection/CardList/Cards/UpcomingShowCard.tsx
@@ -38,10 +38,12 @@ export const UpcomingShowCard: React.FC<Props> = ({ upcomingShow }) => {
 
   return (
     <StyledCard onClick={() => goToShowDetail()}>
-      <StyledCardImage src={posterUrl} alt="poster" />
+      <StyledCardImageContainer>
+        <StyledCardImage src={posterUrl} alt="poster" />
+      </StyledCardImageContainer>
       <StyledTitleContainer>
-        <StyledTitle>{venueName}</StyledTitle>
-        <StyledSubTitle>{teamName}</StyledSubTitle>
+        <StyledTitle>{teamName}</StyledTitle>
+        <StyledSubTitle>{venueName}</StyledSubTitle>
       </StyledTitleContainer>
       <StyledContentContainer>
         <StyledContent>{date}</StyledContent>
@@ -62,31 +64,52 @@ const StyledCard = styled.div`
   width: 100%;
   box-sizing: border-box;
   margin-bottom: 37px;
+
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+const StyledCardImageContainer = styled.div`
+  width: 100%;
+  overflow: hidden;
+  margin-bottom: 24px;
+
+  ${StyledCard}:hover & {
+    opacity: 0.7;
+  }
 `;
 
 const StyledCardImage = styled.img`
   width: 100%;
-  height: 380px;
   object-fit: cover;
-  margin-bottom: 24px;
+  transition: transform 0.3s ease-in-out;
+
+  ${StyledCard}:hover & {
+    transform: scale(1.05);
+  }
 `;
 
 const StyledTitleContainer = styled.div`
   display: flex;
-  flex-direction: column;
+  flex-direction: column-reverse;
   gap: 2px;
   font-size: 22px;
   line-height: 140%;
 `;
 
-const StyledTitle = styled.div`
-  font-weight: 300;
-  color: #141313;
+const StyledTitle = styled.h2`
+  font-weight: 600;
+  letter-spacing: -1px;
+
+  ${StyledCard}:hover & {
+    text-decoration: underline;
+  }
 `;
 
 const StyledSubTitle = styled.div`
-  font-weight: bold;
-  letter-spacing: -1px;
+  font-weight: 300;
+  color: #141313;
 `;
 
 const StyledContentContainer = styled.div`

--- a/fe/user/src/pages/MainPage/MainSection/CardList/Cards/UpcomingShowCard.tsx
+++ b/fe/user/src/pages/MainPage/MainSection/CardList/Cards/UpcomingShowCard.tsx
@@ -3,14 +3,22 @@ import { useNavigate } from 'react-router-dom';
 import { useShallow } from 'zustand/react/shallow';
 import { useShowDetailStore } from '~/stores/useShowDetailStore';
 import { UpcomingShow } from '~/types/api.types';
+import { getFormattedDateString } from '~/utils/dateUtils';
 
 type Props = {
   upcomingShow: UpcomingShow;
 };
 
 export const UpcomingShowCard: React.FC<Props> = ({ upcomingShow }) => {
-  const { venueId, showId, posterUrl, teamName, startTime, endTime } =
-    upcomingShow;
+  const {
+    venueId,
+    venueName,
+    showId,
+    posterUrl,
+    teamName,
+    startTime,
+    endTime,
+  } = upcomingShow;
   const navigate = useNavigate();
   const { setShowDetailId, setShowDetailDate } = useShowDetailStore(
     useShallow((state) => ({
@@ -18,6 +26,10 @@ export const UpcomingShowCard: React.FC<Props> = ({ upcomingShow }) => {
       setShowDetailDate: state.setShowDetailDate,
     })),
   );
+
+  const date = getFormattedDateString(startTime);
+  const timeRange = `${formatTime(startTime)} ~ ${formatTime(endTime)}`;
+
   const goToShowDetail = () => {
     setShowDetailId(showId);
     setShowDetailDate(new Date(startTime));
@@ -28,11 +40,13 @@ export const UpcomingShowCard: React.FC<Props> = ({ upcomingShow }) => {
     <StyledCard onClick={() => goToShowDetail()}>
       <StyledCardImage src={posterUrl} alt="poster" />
       <StyledTitleContainer>
-        <StyledTitle>{teamName}</StyledTitle>
-        <StyledSubTitle>{`${formatTime(startTime)} ~ ${formatTime(
-          endTime,
-        )}`}</StyledSubTitle>
+        <StyledTitle>{venueName}</StyledTitle>
+        <StyledSubTitle>{teamName}</StyledSubTitle>
       </StyledTitleContainer>
+      <StyledContentContainer>
+        <StyledContent>{date}</StyledContent>
+        <StyledContent>{timeRange}</StyledContent>
+      </StyledContentContainer>
     </StyledCard>
   );
 };
@@ -61,19 +75,30 @@ const StyledTitleContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2px;
+  font-size: 22px;
+  line-height: 140%;
 `;
 
 const StyledTitle = styled.div`
-  font-size: 22px;
-  font-weight: bold;
-  line-height: 140%;
+  font-weight: 300;
   color: #141313;
 `;
 
 const StyledSubTitle = styled.div`
-  font-size: 22px;
-  font-weight: medium;
-  line-height: 140%;
+  font-weight: bold;
   letter-spacing: -1px;
+`;
+
+const StyledContentContainer = styled.div`
+  margin-top: 8px;
+  display: flex;
+  gap: 2px;
   color: #686970;
+`;
+
+const StyledContent = styled.div`
+  &:not(:last-of-type)::after {
+    content: '|';
+    margin: 0 8px;
+  }
 `;

--- a/fe/user/src/pages/MainPage/MainSection/CardList/Cards/UpcomingShowCard.tsx
+++ b/fe/user/src/pages/MainPage/MainSection/CardList/Cards/UpcomingShowCard.tsx
@@ -42,8 +42,8 @@ export const UpcomingShowCard: React.FC<Props> = ({ upcomingShow }) => {
         <StyledCardImage src={posterUrl} alt="poster" />
       </StyledCardImageContainer>
       <StyledTitleContainer>
-        <StyledTitle>{teamName}</StyledTitle>
-        <StyledSubTitle>{venueName}</StyledSubTitle>
+        <StyledVenueName>{venueName}</StyledVenueName>
+        <StyledTeamName>{teamName}</StyledTeamName>
       </StyledTitleContainer>
       <StyledContentContainer>
         <StyledContent>{date}</StyledContent>
@@ -92,13 +92,13 @@ const StyledCardImage = styled.img`
 
 const StyledTitleContainer = styled.div`
   display: flex;
-  flex-direction: column-reverse;
+  flex-direction: column;
   gap: 2px;
   font-size: 22px;
   line-height: 140%;
 `;
 
-const StyledTitle = styled.h2`
+const StyledTeamName = styled.h2`
   font-weight: 600;
   letter-spacing: -1px;
 
@@ -107,7 +107,7 @@ const StyledTitle = styled.h2`
   }
 `;
 
-const StyledSubTitle = styled.div`
+const StyledVenueName = styled.div`
   font-weight: 300;
   color: #141313;
 `;

--- a/fe/user/src/types/api.types.ts
+++ b/fe/user/src/types/api.types.ts
@@ -47,6 +47,7 @@ export type VenueDetailData = {
 
 export type UpcomingShow = {
   venueId: number;
+  venueName: string;
   showId: number;
   posterUrl: string;
   teamName: string;

--- a/fe/user/vite.config.ts
+++ b/fe/user/vite.config.ts
@@ -5,5 +5,14 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), svgr(), tsconfigPaths()],
+  plugins: [
+    react({
+      jsxImportSource: '@emotion/react',
+      babel: {
+        plugins: [['@emotion/babel-plugin']],
+      },
+    }),
+    svgr(),
+    tsconfigPaths(),
+  ],
 });


### PR DESCRIPTION
## What is this PR? 👓
메인 화면에 있는 다가오는 공연에 대한 데이터가 부족해서 공연장 이름, 날짜, 시간 등의 정보를 추가했습니다.

## Key changes 🔑
- UpcomingShow 데이터 타입에 venueName 추가
- UpcomingShowCard 레이아웃 변경
- 사용자 인터랙션 효과 추가
![다가오는-공연-인터랙션](https://github.com/jazz-meet/jazz-meet/assets/60080167/c5afd404-9fdc-447e-afa3-e37edb52f4a2)


## To reviewers 👋
- 사용자 인터랙션 효과를 추가하던 중 Component selector를 사용하기 위해 @emotion/babel-plugin을 추가했습니다. 실행하기 전 npm i 부탁드립니다. ([해당 패키지 추가하는 과정](https://www.notion.so/khundi/bf3594a90ab34162bd00a5ddc9479f9c?pvs=4#38523134263f4b9d9974d1b69d79493e))