### PR TITLE
공연장 상세조회 쿼리 개선

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
@@ -12,7 +12,6 @@ import kr.codesquad.jazzmeet.show.dto.request.RegisterShowRequest;
 import kr.codesquad.jazzmeet.show.dto.response.ShowByDateAndVenueResponse;
 import kr.codesquad.jazzmeet.show.dto.response.ShowDetailResponse;
 import kr.codesquad.jazzmeet.show.dto.response.ShowResponse;
-import kr.codesquad.jazzmeet.show.dto.response.UpcomingShowResponse;
 import kr.codesquad.jazzmeet.show.entity.Show;
 import kr.codesquad.jazzmeet.show.vo.ShowSummaryWithVenue;
 import kr.codesquad.jazzmeet.venue.entity.Venue;
@@ -20,11 +19,6 @@ import kr.codesquad.jazzmeet.venue.entity.Venue;
 @Mapper
 public interface ShowMapper {
 	ShowMapper INSTANCE = Mappers.getMapper(ShowMapper.class);
-
-	@Mapping(target = "venueId", source = "venue.id")
-	@Mapping(target = "showId", source = "id")
-	@Mapping(target = "posterUrl", source = "poster.url")
-	UpcomingShowResponse toUpcomingShowResponse(Show show);
 
 	@Mapping(target = "posterUrl", source = "poster.url")
 	ShowByDateAndVenueResponse toShowByDateResponse(Show show);

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowService.java
@@ -55,7 +55,7 @@ public class ShowService {
 	private static final String FIRST_DAY_OF_MONTH = "01";
 
 	public List<UpcomingShowResponse> getUpcomingShows(LocalDateTime nowTime) {
-		// 10개 제한, 현재 시간 < 공연 시작 시간 , 현재 시간 < 공연 끝나는 시간, 공연 시작 시간 순으로 오름차순 정렬
+		// 10개 제한, 현재 시간 < 공연 끝나는 시간, 공연 시작 시간 순으로 오름차순 정렬
 		return showQueryRepository.getUpcomingShows(nowTime);
 	}
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/vo/VenueDetail.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/vo/VenueDetail.java
@@ -1,6 +1,6 @@
 package kr.codesquad.jazzmeet.venue.vo;
 
-import java.util.List;
+import java.util.Set;
 
 import org.locationtech.jts.geom.Point;
 
@@ -18,14 +18,14 @@ public class VenueDetail {
 	private String phoneNumber;
 	private String description;
 	private Point location;
-	private List<VenueDetailImage> images;
-	private List<VenueDetailLink> links;
-	private List<VenueDetailVenueHour> venueHours;
+	private Set<VenueDetailImage> images;
+	private Set<VenueDetailLink> links;
+	private Set<VenueDetailVenueHour> venueHours;
 
 	@Builder
 	public VenueDetail(Long id, String name, String roadNameAddress, String lotNumberAddress, String phoneNumber,
-		String description, Point location, List<VenueDetailImage> images, List<VenueDetailLink> links,
-		List<VenueDetailVenueHour> venueHours) {
+		String description, Point location, Set<VenueDetailImage> images, Set<VenueDetailLink> links,
+		Set<VenueDetailVenueHour> venueHours) {
 		this.id = id;
 		this.name = name;
 		this.roadNameAddress = roadNameAddress;

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/vo/VenueDetailImage.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/vo/VenueDetailImage.java
@@ -1,10 +1,12 @@
 package kr.codesquad.jazzmeet.venue.vo;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@EqualsAndHashCode
 public class VenueDetailImage {
 	private Long id;
 	private String url;

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/vo/VenueDetailLink.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/vo/VenueDetailLink.java
@@ -1,17 +1,18 @@
 package kr.codesquad.jazzmeet.venue.vo;
 
-import kr.codesquad.jazzmeet.venue.entity.LinkType;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@EqualsAndHashCode
 public class VenueDetailLink {
 	private String type;
 	private String url;
 
-	public VenueDetailLink(LinkType type, String url) {
-		this.type = type.getName();
+	public VenueDetailLink(String type, String url) {
+		this.type = type;
 		this.url = url;
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/venue/vo/VenueDetailVenueHour.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/venue/vo/VenueDetailVenueHour.java
@@ -1,11 +1,13 @@
 package kr.codesquad.jazzmeet.venue.vo;
 
 import kr.codesquad.jazzmeet.venue.entity.DayOfWeek;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@EqualsAndHashCode
 public class VenueDetailVenueHour {
 	private String day;
 	private String businessHours;


### PR DESCRIPTION
## What is this PR? 👓
- 공연장 상세조회 시 이미지, 링크, 영업시간 목록을 나눠서 조회하던 구조에서 left join을 이용해서 하나의 쿼리로 조회하도록 개선했습니다.
- 한번에 조회 시 이미지 개수 x 링크 개수 x 영업시간 개수만큼 중복되서 조회되는 문제가 발생해서 DTO 내부의 List를 Set으로 담아서 매핑하도록 했습니다.
- Set에 들어가는 DTO를 구분하기 위해서 `@EqualsAndHashCode`를 사용했습니다.