### PR TITLE
fix: reissue 요청 방식 변경

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/admin/controller/AdminController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/admin/controller/AdminController.java
@@ -9,19 +9,21 @@ import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import kr.codesquad.jazzmeet.admin.AdminMapper;
 import kr.codesquad.jazzmeet.admin.dto.request.LoginAdminRequest;
-import kr.codesquad.jazzmeet.admin.dto.request.ReissueAdminRequest;
 import kr.codesquad.jazzmeet.admin.dto.request.SignUpAdminRequest;
 import kr.codesquad.jazzmeet.admin.dto.response.LoginAdminResponse;
 import kr.codesquad.jazzmeet.admin.entity.Admin;
 import kr.codesquad.jazzmeet.admin.service.AdminService;
+import kr.codesquad.jazzmeet.global.error.CustomException;
+import kr.codesquad.jazzmeet.global.error.statuscode.AdminErrorCode;
 import kr.codesquad.jazzmeet.global.jwt.Jwt;
 import kr.codesquad.jazzmeet.global.jwt.JwtProperties;
 import kr.codesquad.jazzmeet.global.permission.AdminAuth;
 import kr.codesquad.jazzmeet.global.permission.Permission;
-import kr.codesquad.jazzmeet.global.util.PasswordEncoder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -70,13 +72,26 @@ public class AdminController {
 	 * 관리자 토큰 재발급 API
 	 */
 	@PostMapping("/api/admins/reissue")
-	public ResponseEntity<LoginAdminResponse> reissueToken(@RequestBody @Valid ReissueAdminRequest reissueAdminRequest) {
+	public ResponseEntity<LoginAdminResponse> reissueToken(HttpServletRequest request) {
 
-		Jwt jwt = adminService.reissue(reissueAdminRequest);
+		String refreshToken = extractRefreshToken(request.getCookies());
+
+		Jwt jwt = adminService.reissue(refreshToken);
 
 		return ResponseEntity.ok()
 			.header(HttpHeaders.SET_COOKIE, getRefreshToken(jwt).toString())
 			.body(AdminMapper.INSTANCE.toLoginAdminResponse(jwt));
+	}
+
+	private String extractRefreshToken(Cookie[] cookies) {
+		if (cookies == null)
+			throw new CustomException(AdminErrorCode.NOT_EXIST_COOKIE);
+		for (Cookie cookie : cookies) {
+			if ("refreshToken".equals(cookie.getName())) {
+				return cookie.getValue();
+			}
+		}
+		throw new CustomException(AdminErrorCode.NOT_FOUND_TOKEN_COOKIE);
 	}
 
 	/**

--- a/be/src/main/java/kr/codesquad/jazzmeet/admin/service/AdminService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/admin/service/AdminService.java
@@ -73,8 +73,7 @@ public class AdminService {
 		return jwt;
 	}
 
-	public Jwt reissue(ReissueAdminRequest reissueAdminRequest) {
-		String refreshToken = reissueAdminRequest.refreshToken();
+	public Jwt reissue(String refreshToken) {
 		jwtProvider.validateAndGetClaims(refreshToken);
 		Admin admin = getAdminByRefreshToken(refreshToken);
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/AdminErrorCode.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/AdminErrorCode.java
@@ -9,7 +9,9 @@ public enum AdminErrorCode implements StatusCode {
 	NOT_FOUND_ADMIN(HttpStatus.NOT_FOUND, "해당하는 계정을 찾을 수 없습니다."),
 	ALREADY_EXIST_ADMIN(HttpStatus.BAD_REQUEST, "이미 존재하는 로그인 아이디입니다."),
 	UNAUTHORIZED_ROLE(HttpStatus.UNAUTHORIZED, "루트 관리자 계정이 아닙니다."),
-	NOT_EXIST_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다." );
+	NOT_EXIST_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다." ),
+	NOT_EXIST_COOKIE(HttpStatus.BAD_REQUEST, "쿠키가 전혀 존재하지 않습니다." ),
+	NOT_FOUND_TOKEN_COOKIE(HttpStatus.UNAUTHORIZED, "필요한 refresh token 쿠키를 찾을 수 없습니다." );
 
 	private final HttpStatus httpStatus;
 	private final String message;


### PR DESCRIPTION
## What is this PR? 👓
__문제__
프론트에서 httpOnly cookie로 설정된 refresh token을 핸들링하여 Request Body로 넘겨주지 못하는 문제가 있었습니다.

__해결__
로그인 시 서버에서 세팅한 path에 요청이 들어올 경우 httpOnly로 설정한 쿠키를 브라우저에서 자동으로 보내줍니다.
따라서 Request Body로 데이터를 요청 받는 것이 아닌 Servlet Request에서 직접 쿠키를 추출하여 사용하는 방식으로 변경하였습니다.
