### PR TITLE
Fix/be/#325 cors httponly 추가

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,7 +9,7 @@ name: ci-cd
 
 on:
   push:
-    branches: [ infra/#11-cicd, release ]
+    branches: [ infra/#11-cicd, release, fix/be/#325-cors_httponly_추가 ]
 
 permissions:
   contents: read
@@ -62,7 +62,8 @@ jobs:
       # docker build & push to devleop
       - name: Docker build & push to release
         if: contains(github.ref, 'release') ||
-          contains(github.ref, 'infra/#11-cicd')
+          contains(github.ref, 'infra/#11-cicd') ||
+          contains(github.ref, 'fix/be/#325-cors_httponly_추가')
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
           docker build -f Dockerfile -t ${{ secrets.DOCKER_USERNAME }}/jazz_meet_app_release .
@@ -90,7 +91,8 @@ jobs:
 
       - name: Docker build to release
         if: contains(github.ref, 'release') ||
-          contains(github.ref, 'infra/#11-cicd')
+          contains(github.ref, 'infra/#11-cicd') ||
+          contains(github.ref, 'fix/be/#325-cors_httponly_추가')
         run: |
           ls -la
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
@@ -112,7 +114,8 @@ jobs:
       - name: copy nginx.conf file via ssh password
         uses: appleboy/scp-action@master
         if: contains(github.ref, 'release') ||
-          contains(github.ref, 'infra/#11-cicd')
+          contains(github.ref, 'infra/#11-cicd') ||
+          contains(github.ref, 'fix/be/#325-cors_httponly_추가')
         with:
           host: ${{ secrets.HOST }}
           username: ubuntu
@@ -125,7 +128,8 @@ jobs:
       - name: copy docker-compose file via ssh password
         uses: appleboy/scp-action@master
         if: contains(github.ref, 'release') ||
-          contains(github.ref, 'infra/#11-cicd')
+          contains(github.ref, 'infra/#11-cicd') ||
+          contains(github.ref, 'fix/be/#325-cors_httponly_추가')
         with:
           host: ${{ secrets.HOST }}
           username: ubuntu
@@ -138,7 +142,8 @@ jobs:
       - name: Deploy to release
         uses: appleboy/ssh-action@master
         if: contains(github.ref, 'release') ||
-          contains(github.ref, 'infra/#11-cicd')
+          contains(github.ref, 'infra/#11-cicd') ||
+          contains(github.ref, 'fix/be/#325-cors_httponly_추가')
         with:
           host: ${{ secrets.HOST }}  # EC2 인스턴스 퍼블릭 DNS
           username: ubuntu

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,7 +9,7 @@ name: ci-cd
 
 on:
   push:
-    branches: [ infra/#11-cicd, release, fix/be/#325-cors_httponly_추가 ]
+    branches: [ infra/#11-cicd, release ]
 
 permissions:
   contents: read
@@ -62,8 +62,7 @@ jobs:
       # docker build & push to devleop
       - name: Docker build & push to release
         if: contains(github.ref, 'release') ||
-          contains(github.ref, 'infra/#11-cicd') ||
-          contains(github.ref, 'fix/be/#325-cors_httponly_추가')
+          contains(github.ref, 'infra/#11-cicd')
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
           docker build -f Dockerfile -t ${{ secrets.DOCKER_USERNAME }}/jazz_meet_app_release .
@@ -91,8 +90,7 @@ jobs:
 
       - name: Docker build to release
         if: contains(github.ref, 'release') ||
-          contains(github.ref, 'infra/#11-cicd') ||
-          contains(github.ref, 'fix/be/#325-cors_httponly_추가')
+          contains(github.ref, 'infra/#11-cicd')
         run: |
           ls -la
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
@@ -114,8 +112,7 @@ jobs:
       - name: copy nginx.conf file via ssh password
         uses: appleboy/scp-action@master
         if: contains(github.ref, 'release') ||
-          contains(github.ref, 'infra/#11-cicd') ||
-          contains(github.ref, 'fix/be/#325-cors_httponly_추가')
+          contains(github.ref, 'infra/#11-cicd')
         with:
           host: ${{ secrets.HOST }}
           username: ubuntu
@@ -128,8 +125,7 @@ jobs:
       - name: copy docker-compose file via ssh password
         uses: appleboy/scp-action@master
         if: contains(github.ref, 'release') ||
-          contains(github.ref, 'infra/#11-cicd') ||
-          contains(github.ref, 'fix/be/#325-cors_httponly_추가')
+          contains(github.ref, 'infra/#11-cicd')
         with:
           host: ${{ secrets.HOST }}
           username: ubuntu
@@ -142,8 +138,7 @@ jobs:
       - name: Deploy to release
         uses: appleboy/ssh-action@master
         if: contains(github.ref, 'release') ||
-          contains(github.ref, 'infra/#11-cicd') ||
-          contains(github.ref, 'fix/be/#325-cors_httponly_추가')
+          contains(github.ref, 'infra/#11-cicd')
         with:
           host: ${{ secrets.HOST }}  # EC2 인스턴스 퍼블릭 DNS
           username: ubuntu

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/config/WebConfig.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/config/WebConfig.java
@@ -21,9 +21,11 @@ public class WebConfig implements WebMvcConfigurer {
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
-		registry.addMapping("/**")
-			.allowedOrigins("*")
-			.allowedMethods("GET", "POST", "PUT", "DELETE");
+		registry.addMapping("/api/**")
+			.allowedOrigins("https://www.jazzmeet-admin.site", "https://jazzmeet.site", "https://localhost:3000")
+			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+			.allowCredentials(true)
+			.allowedHeaders("*");
 	}
 
 	@Override


### PR DESCRIPTION
## What is this PR? 👓
__상황__
프론트에서 API 요쳥을 보낼 때 쿠키가 자동으로 반영이 되지 않는 문제가 발생했습니다.

__문제__
프론트에서도 credentials: 'include'  설정을 추가해 주어야 합니다. 
- 요청을 할 때 인증 정보(예: 쿠키, HTTP 인증 토큰 등)를 요청에 포함시키기 위한 설정
기존에는 이 설정을 추가할 경우 CORS문제가 발생했고, 쿠키를 포함하는 것을 허락하는 cors 설정이 추가로 필요했습니다.

__해결__
다음과 같은 설정으로 변경하였습니다.
```java
@Override
public void addCorsMappings(CorsRegistry registry) {
  registry.addMapping("/api/**")
	  .allowedOrigins("https://www.jazzmeet-admin.site", "https://jazzmeet.site", "https://localhost:3000")
	  .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
	  .allowCredentials(true)
	  .allowedHeaders("*");
}
```
각각의 의미는 다음과 같습니다.
- addMapping : /api로 시작하는 모든 URL에 대해 CORS 정책이 적용됩니다.
- allowedOrigins : 지정된 출처(origin)의 요청만 서버가 수락하도록 허용합니다.
  - 여기에 구체적인 출처를 명시하면 스프링은 `Access-Control-Allow-Origin` 헤더를 자동으로 만들어줍니다. 브라우저의 보안 정책에 따라, allowCredentials(true) 설정을 사용하면 `Access-Control-Allow-Origin` 헤더에 구체적인 출처(와일드카드 대신)를 요구합니다.
- allowedMethods : 허용할 HTTP 메서드를 지정합니다. 
  - OPTIONS: 서버가 지원하는 메서드를 조회할 때 사용되며, CORS preflight 요청에 대응하기 위해 필요합니다.
- allowCredentials : 크로스 오리진 요청 시 쿠키와 같은 인증 정보를 포함할 수 있도록 허용합니다. 
- allowedHeaders : 설정한 HTTP 헤더를 요청에서 허용하겠다는 것을 의미합니다. 