### PR TITLE
fix: 쿠키에 도메인 직접 설정 - 이름 변경

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/admin/controller/AdminController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/admin/controller/AdminController.java
@@ -66,7 +66,7 @@ public class AdminController {
 			// .secure(true) // 개발 완료 시 주석 해제하여 https 환경에서만 접근 가능하도록 변경하기
 			.httpOnly(false)
 			.sameSite("None")
-			.domain("jazzmeet-admin.site")
+			.domain("https://www.jazzmeet-admin.site")
 			.build();
 	}
 


### PR DESCRIPTION
도메인 명을 `jazzmeet-admin.site` 에서 `https://www.jazzmeet-admin.site`로 변경했습니다.
배포할게요~