### PR TITLE
fix: 서브도메인으로 변경

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/admin/controller/AdminController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/admin/controller/AdminController.java
@@ -65,6 +65,7 @@ public class AdminController {
 			.path("/")
 			.secure(true)
 			.httpOnly(false)
+			.domain(".jazzmeet.site")
 			.sameSite("None")
 			.build();
 	}

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/config/WebConfig.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/config/WebConfig.java
@@ -22,7 +22,7 @@ public class WebConfig implements WebMvcConfigurer {
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/api/**")
-			.allowedOrigins("https://www.jazzmeet-admin.site", "https://jazzmeet.site", "https://localhost:3000", "http://localhost:3000")
+			.allowedOrigins("https://admin.jazzmeet.site", "https://jazzmeet.site", "https://localhost:3000", "http://localhost:3000")
 			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
 			.allowCredentials(true)
 			.allowedHeaders("*");


### PR DESCRIPTION
기존 jazzmeet-admin.site 에 배포된 프론트 도메인으로 admin.jazzmeet.site로 바꿨습니다.
거기에 맞춰서 코드도 수정했습니다. 
쿠키 생성 코드에서 domain 설정에 `.jazzmeet.site`는 jazzmeet.site의 하위 도메인에게도 쿠키를 허용한다는 설정입니다.