### PR TITLE
nginx 프록시 쿠키 경로 설정

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -46,6 +46,8 @@ http {
           proxy_set_header   X-Real-IP $remote_addr;
           proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header   X-Forwarded-Host $server_name;
+          proxy_cookie_path / "/; SameSite=None; Secure";
+
         }
 
         location / {


### PR DESCRIPTION
프론트의 admin 도메인을 jazzmeet.site의 하위로 만들어도 여전히 쿠키가 저장되지 않는 문제가 발생했습니다.
nginx 문제인 것 같아 nginx에 proxy_cookie_path 설정을 추가했습니다.
바로 배포하겠습니다.