### PR TITLE
fix: 서브 도메인 사용 시 sameSite lax 사용하도록 변경

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/admin/controller/AdminController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/admin/controller/AdminController.java
@@ -66,7 +66,7 @@ public class AdminController {
 			.secure(true)
 			.httpOnly(false)
 			.domain(".jazzmeet.site")
-			.sameSite("None")
+			// .sameSite("None")
 			.build();
 	}
 


### PR DESCRIPTION
sameSite 설정을 기본 lax로 바꿔주었을 때 제대로 동작하는지 확인해보겠습니다.
바로 배포하겠습니다.
