### PR TITLE
블랙리스트 삭제

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/admin/controller/AdminController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/admin/controller/AdminController.java
@@ -101,8 +101,8 @@ public class AdminController {
 	 */
 	@Permission
 	@PostMapping("/api/admins/logout")
-	public ResponseEntity<Void> logout(@AdminAuth Admin admin, @RequestAttribute String accessToken) {
-		adminService.logout(admin, accessToken);
+	public ResponseEntity<Void> logout(@AdminAuth Admin admin) {
+		adminService.logout(admin);
 		return ResponseEntity.ok().build();
 	}
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/admin/service/AdminService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/admin/service/AdminService.java
@@ -90,9 +90,7 @@ public class AdminService {
 	}
 
 	@Transactional
-	public void logout(Admin admin, String accessToken) {
+	public void logout(Admin admin) {
 		adminRepository.deleteRefreshTokenById(admin.getId());
-		Long expiration = jwtProvider.getExpiration(accessToken);
-		redisUtil.setBlackList(accessToken, "accessToken", expiration);
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/jwt/JwtProvider.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/jwt/JwtProvider.java
@@ -71,9 +71,4 @@ public class JwtProvider {
 		return claims.getExpiration().getTime();
 	}
 
-	public void validateBlackList(String token) {
-		if(redisUtil.hasKeyBlackList(token)){
-			throw new CustomException(ErrorCode.EXIST_LOGOUT_USER);
-		}
-	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/permission/PermissionInterceptor.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/permission/PermissionInterceptor.java
@@ -45,9 +45,6 @@ public class PermissionInterceptor implements HandlerInterceptor {
 
 		String token = extractJwtTokenFromHeader(request);
 
-		// Blacklist 존재하는지 확인
-		jwtProvider.validateBlackList(token);
-
 		Claims claims = jwtProvider.validateAndGetClaims(token);
 		String role = String.valueOf(claims.get("role"));
 		String adminId = String.valueOf(claims.get("adminId"));
@@ -55,14 +52,12 @@ public class PermissionInterceptor implements HandlerInterceptor {
 		// 일반 관리자인 경우
 		if (role.equals(UserRole.ADMIN.name())) {
 			request.setAttribute("adminId", adminId);
-			request.setAttribute("accessToken", token);
 			return true;
 		}
 
 		// 루트 관리자인 경우
 		if (role.equals(UserRole.ROOT_ADMIN.name())) {
 			request.setAttribute("adminId", adminId);
-			request.setAttribute("accessToken", token);
 			return true;
 		}
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/util/RedisUtil.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/util/RedisUtil.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RedisUtil {
 	private final RedisTemplate<String, Object> redisTemplate;
-	private final RedisTemplate<String, Object> redisBlackListTemplate;
 
 	public void set(String key, Object o, int minutes) {
 		redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer(o.getClass()));
@@ -31,20 +30,4 @@ public class RedisUtil {
 		return redisTemplate.hasKey(key);
 	}
 
-	public void setBlackList(String key, Object o, Long milliSeconds) {
-		redisBlackListTemplate.setValueSerializer(new Jackson2JsonRedisSerializer(o.getClass()));
-		redisBlackListTemplate.opsForValue().set(key, o, milliSeconds, TimeUnit.MILLISECONDS);
-	}
-
-	public Object getBlackList(String key) {
-		return redisBlackListTemplate.opsForValue().get(key);
-	}
-
-	public boolean deleteBlackList(String key) {
-		return redisBlackListTemplate.delete(key);
-	}
-
-	public boolean hasKeyBlackList(String key) {
-		return redisBlackListTemplate.hasKey(key);
-	}
 }


### PR DESCRIPTION
## What is this PR? 👓
`@Permission` 어노테이션이 달린 API에 요청이 들어올 때 항상 검사하던 블랙리스트를 삭제했습니다.
아무래도 로그아웃한 유저인지를 항상 체크하는 것은 세션 저장소로 Redis를 사용하는 것과 다를 바가 없다고 판단했습니다.
가볍다는 JWT의 장점도 살리지 못하기도 하고, 짧은 유효기간을 가진 access token만으로 어느 정도는 보안을 챙길 수 있다고 생각했습니다.
더해서 그렇게 보안을 생각한다면 세션을 사용하는 것이 맞다고 생각해서 블랙리스트를 삭제하였습니다.

