### PR TITLE
공연 등록 시 Admin 추가

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/admin/service/AdminService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/admin/service/AdminService.java
@@ -50,7 +50,7 @@ public class AdminService {
 		}
 	}
 
-	private Admin findAdminByLoginId(String loginId) {
+	public Admin findAdminByLoginId(String loginId) {
 		return adminRepository.findByLoginId(loginId)
 			.orElseThrow(() -> new CustomException(AdminErrorCode.NOT_FOUND_ADMIN));
 	}

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/controller/ShowController.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/controller/ShowController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import kr.codesquad.jazzmeet.admin.entity.Admin;
+import kr.codesquad.jazzmeet.global.permission.AdminAuth;
 import kr.codesquad.jazzmeet.global.permission.Permission;
 import kr.codesquad.jazzmeet.show.dto.request.RegisterShowRequest;
 import kr.codesquad.jazzmeet.show.dto.response.ExistShowCalendarResponse;
@@ -116,9 +118,9 @@ public class ShowController {
 	 */
 	@Permission
 	@PostMapping("/api/shows/{venueId}")
-	public ResponseEntity<RegisterShowResponse> registerShow(@PathVariable Long venueId,
+	public ResponseEntity<RegisterShowResponse> registerShow(@AdminAuth Admin admin, @PathVariable Long venueId,
 		@Valid @RequestBody RegisterShowRequest registerShowRequest) {
-		RegisterShowResponse response = showService.registerShow(venueId, registerShowRequest);
+		RegisterShowResponse response = showService.registerShow(venueId, registerShowRequest, admin);
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/entity/Show.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/entity/Show.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import kr.codesquad.jazzmeet.admin.entity.Admin;
 import kr.codesquad.jazzmeet.image.entity.Image;
 import kr.codesquad.jazzmeet.venue.entity.Venue;
 import lombok.AccessLevel;
@@ -41,17 +42,20 @@ public class Show {
 	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
 	@JoinColumn(name = "poster_id")
 	private Image poster;
-	private Long adminId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "admin_id")
+	private Admin admin;
 
 	@Builder
 	public Show(String teamName, String description, LocalDateTime startTime, LocalDateTime endTime, Venue venue,
-		Image poster) {
+		Image poster, Admin admin) {
 		this.teamName = teamName;
 		this.description = description;
 		this.startTime = startTime;
 		this.endTime = endTime;
 		this.venue = venue;
 		this.poster = poster;
+		this.admin = admin;
 	}
 
 	public void updateShow(String teamName, String description, LocalDateTime startTime, LocalDateTime endTime,

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/mapper/ShowMapper.java
@@ -7,6 +7,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 import org.springframework.data.domain.Page;
 
+import kr.codesquad.jazzmeet.admin.entity.Admin;
 import kr.codesquad.jazzmeet.image.entity.Image;
 import kr.codesquad.jazzmeet.show.dto.request.RegisterShowRequest;
 import kr.codesquad.jazzmeet.show.dto.response.ShowByDateAndVenueResponse;
@@ -33,7 +34,7 @@ public interface ShowMapper {
 	ShowDetailResponse toShowDetailResponse(Show show);
 
 	@Mapping(target = "description", source = "registerShowRequest.description")
-	Show toShow(RegisterShowRequest registerShowRequest, Venue venue, Image poster);
+	Show toShow(RegisterShowRequest registerShowRequest, Venue venue, Image poster, Admin admin);
 
 	RegisterShowRequest toRegisterShowRequest(String teamName, String description, Long posterId,
 		LocalDateTime startTime, LocalDateTime endTime);

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowScheduler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowScheduler.java
@@ -8,6 +8,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import kr.codesquad.jazzmeet.admin.entity.Admin;
+import kr.codesquad.jazzmeet.admin.service.AdminService;
 import kr.codesquad.jazzmeet.show.dto.request.RegisterShowRequest;
 import kr.codesquad.jazzmeet.show.repository.OcrHandler;
 import kr.codesquad.jazzmeet.show.repository.WebCrawler;
@@ -22,9 +24,11 @@ import lombok.extern.log4j.Log4j2;
 public class ShowScheduler {
 	public static final String ENTRY55 = "entry55";
 	public static final String ENTRY55_INSTAGRAM_URL = "https://www.instagram.com/entry55_official/";
+	public static final String AUTO_ADMIN_ID = "auto_admin";
 
 	private final ShowService showService;
 	private final VenueService venueService;
+	private final AdminService adminService;
 	private final OcrHandler ocrHandler;
 	private final WebCrawler crawler;
 
@@ -42,6 +46,9 @@ public class ShowScheduler {
 		Venue venue = venueService.findByName(ENTRY55);
 		String venueInstagramUrl = ENTRY55_INSTAGRAM_URL;
 
+		// 자동화로 공연을 저장할 Admin
+		Admin autoAdmin = adminService.findAdminByLoginId(AUTO_ADMIN_ID);
+
 		// 공연장에 저장 된 최신 공연을 가져온다.
 		LocalDate latestShowDate = showService.getLatestShowBy(venue.getId())
 			.map(show -> show.getStartTime().toLocalDate())
@@ -56,7 +63,7 @@ public class ShowScheduler {
 				showImageUrls.get(showImageUrl), latestShowDate);
 			// 3. DB에 새로운 공연을 넣는다.
 			for (RegisterShowRequest request : requests) {
-				showService.registerShow(venue.getId(), request);
+				showService.registerShow(venue.getId(), request, autoAdmin);
 			}
 		}
 	}

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/service/ShowService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import kr.codesquad.jazzmeet.admin.entity.Admin;
 import kr.codesquad.jazzmeet.global.error.CustomException;
 import kr.codesquad.jazzmeet.global.error.statuscode.ShowErrorCode;
 import kr.codesquad.jazzmeet.image.entity.Image;
@@ -132,14 +133,14 @@ public class ShowService {
 	}
 
 	@Transactional
-	public RegisterShowResponse registerShow(Long venueId, RegisterShowRequest registerShowRequest) {
+	public RegisterShowResponse registerShow(Long venueId, RegisterShowRequest registerShowRequest, Admin admin) {
 		Venue venue = venueService.findById(venueId);
 		Long posterId = registerShowRequest.posterId();
 		Image poster = null;
 		if (posterId != null) {
 			poster = imageService.findById(posterId);
 		}
-		Show show = ShowMapper.INSTANCE.toShow(registerShowRequest, venue, poster);
+		Show show = ShowMapper.INSTANCE.toShow(registerShowRequest, venue, poster, admin);
 
 		Show savedShow = showRepository.save(show);
 

--- a/be/src/test/java/kr/codesquad/jazzmeet/admin/service/AdminServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/admin/service/AdminServiceTest.java
@@ -2,19 +2,17 @@ package kr.codesquad.jazzmeet.admin.service;
 
 import static org.assertj.core.api.Assertions.*;
 
-import org.apache.juli.logging.Log;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import kr.codesquad.jazzmeet.IntegrationTestSupport;
-import kr.codesquad.jazzmeet.admin.AdminMapper;
 import kr.codesquad.jazzmeet.admin.dto.request.LoginAdminRequest;
 import kr.codesquad.jazzmeet.admin.dto.request.SignUpAdminRequest;
 import kr.codesquad.jazzmeet.admin.entity.Admin;
 import kr.codesquad.jazzmeet.admin.entity.UserRole;
+import kr.codesquad.jazzmeet.admin.mapper.AdminMapper;
 import kr.codesquad.jazzmeet.admin.repository.AdminRepository;
 import kr.codesquad.jazzmeet.fixture.AdminFixture;
 import kr.codesquad.jazzmeet.global.error.CustomException;

--- a/be/src/test/java/kr/codesquad/jazzmeet/show/controller/ShowControllerTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/show/controller/ShowControllerTest.java
@@ -154,7 +154,7 @@ class ShowControllerTest {
 			.endTime(LocalDateTime.of(2023, 11, 13, 19, 00))
 			.build();
 
-		when(showService.registerShow(any(), any())).thenReturn(new RegisterShowResponse(1L));
+		when(showService.registerShow(any(), any(), any())).thenReturn(new RegisterShowResponse(1L));
 
 		//when //then
 		mockMvc.perform(
@@ -179,7 +179,7 @@ class ShowControllerTest {
 			.endTime(LocalDateTime.of(2023, 11, 13, 19, 00))
 			.build();
 
-		when(showService.registerShow(any(), any())).thenReturn(new RegisterShowResponse(1L));
+		when(showService.registerShow(any(), any(), any())).thenReturn(new RegisterShowResponse(1L));
 
 		//when //then
 		mockMvc.perform(

--- a/be/src/test/java/kr/codesquad/jazzmeet/show/service/ShowServiceTest.java
+++ b/be/src/test/java/kr/codesquad/jazzmeet/show/service/ShowServiceTest.java
@@ -14,6 +14,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import kr.codesquad.jazzmeet.IntegrationTestSupport;
+import kr.codesquad.jazzmeet.admin.entity.Admin;
+import kr.codesquad.jazzmeet.admin.entity.UserRole;
+import kr.codesquad.jazzmeet.admin.repository.AdminRepository;
+import kr.codesquad.jazzmeet.fixture.AdminFixture;
 import kr.codesquad.jazzmeet.fixture.ImageFixture;
 import kr.codesquad.jazzmeet.fixture.ShowFixture;
 import kr.codesquad.jazzmeet.fixture.VenueFixture;
@@ -44,12 +48,15 @@ class ShowServiceTest extends IntegrationTestSupport {
 	VenueRepository venueRepository;
 	@Autowired
 	ImageRepository imageRepository;
+	@Autowired
+	AdminRepository adminRepository;
 
 	@AfterEach
 	void dbClean() {
 		showRepository.deleteAllInBatch();
 		venueRepository.deleteAllInBatch();
 		imageRepository.deleteAllInBatch();
+		adminRepository.deleteAllInBatch();
 	}
 
 	@Test
@@ -438,8 +445,11 @@ class ShowServiceTest extends IntegrationTestSupport {
 			.endTime(LocalDateTime.of(2023, 11, 13, 11, 50))
 			.build();
 
+		Admin admin = AdminFixture.createAdmin("admin1", "1234", UserRole.ROOT_ADMIN);
+		adminRepository.save(admin);
+
 		//when
-		RegisterShowResponse response = showService.registerShow(venueId, request);
+		RegisterShowResponse response = showService.registerShow(venueId, request, admin);
 
 		//then
 		assertThat(response.id()).isNotNull();


### PR DESCRIPTION
## What is this PR? 👓
- 공연 등록에 Admin도 추가하도록 수정했습니다.
- 자동화 공연 등록 계정(id: `auto_admin`, pw: `auto_admin`)
- 자동화 공연을 등록하는 Admin 계정은 로그인 할 필요가 없다고 생각해서 인코딩 하지 않고 id와 pw 모두 "auto_admin"으로 결정했는데 다른 의견 있으시면 알려주세요.
- 계정은 운영db에 추가했고 notion 계정 페이지에도 추가해놨습니다.
- 공연 등록은 테스트 해봤는데 자동화 공연 등록은 테스트해봐야 할 것 같아요.

- `ShowControllerTest `클래스에 공연 등록할 때 `any()` 만 추가했는데 이런 에러가 발생하는데 저만 그런건지 궁금하네요...
![image](https://github.com/jazz-meet/jazz-meet/assets/57559288/0e90315d-4089-44bc-8de9-2b70465ad40b)
