### PR TITLE
Be/fix/#366 공연 자동화 entry55 크롤링 스크립트 수정

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ShowErrorCode.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ShowErrorCode.java
@@ -12,6 +12,7 @@ public enum ShowErrorCode implements StatusCode {
 	// 웹 크롤링 실패
 	CRAWLING_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 URL 추출에 실패했습니다."),
 	NOT_FOUND_SHOW_IMAGE_URL(HttpStatus.EXPECTATION_FAILED, "해당하는 이미지 url을 찾지 못했습니다."),
+	NOT_FOUND_SHOW_DATE(HttpStatus.NOT_FOUND, "공연 정보에서 공연 날짜를 찾지 못했습니다."),
 	// OCR 실패
 	OCR_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OCR 요청이 실패했습니다."),
 	OCR_NOT_MATCHED_VENUE_AND_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "자동 인식 된 OCR 템플릿이 공연장과 일치하지 않습니다."),

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ShowErrorCode.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ShowErrorCode.java
@@ -14,7 +14,7 @@ public enum ShowErrorCode implements StatusCode {
 	NOT_FOUND_SHOW_IMAGE_URL(HttpStatus.EXPECTATION_FAILED, "해당하는 이미지 url을 찾지 못했습니다."),
 	NOT_FOUND_SHOW_DATE(HttpStatus.EXPECTATION_FAILED, "공연 정보에서 공연 날짜를 찾지 못했습니다."),
 	// OCR 실패
-	OCR_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OCR 요청이 실패했습니다."),
+	OCR_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OCR이 실패했습니다."),
 	OCR_NOT_MATCHED_VENUE_AND_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "자동 인식 된 OCR 템플릿이 공연장과 일치하지 않습니다."),
 	OCR_EXTRACTION_FAILED_SHOW_DATE(HttpStatus.INTERNAL_SERVER_ERROR, "OCR 공연 날짜 인식 및 추출에 실패했습니다."),
 	OCR_EXTRACTION_FAILED_ARTISTS_AND_DETAILS(HttpStatus.INTERNAL_SERVER_ERROR, "OCR 아티스트와 상세 정보 인식 및 추출에 실패했습니다."),

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ShowErrorCode.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/error/statuscode/ShowErrorCode.java
@@ -12,7 +12,7 @@ public enum ShowErrorCode implements StatusCode {
 	// 웹 크롤링 실패
 	CRAWLING_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 URL 추출에 실패했습니다."),
 	NOT_FOUND_SHOW_IMAGE_URL(HttpStatus.EXPECTATION_FAILED, "해당하는 이미지 url을 찾지 못했습니다."),
-	NOT_FOUND_SHOW_DATE(HttpStatus.NOT_FOUND, "공연 정보에서 공연 날짜를 찾지 못했습니다."),
+	NOT_FOUND_SHOW_DATE(HttpStatus.EXPECTATION_FAILED, "공연 정보에서 공연 날짜를 찾지 못했습니다."),
 	// OCR 실패
 	OCR_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OCR 요청이 실패했습니다."),
 	OCR_NOT_MATCHED_VENUE_AND_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "자동 인식 된 OCR 템플릿이 공연장과 일치하지 않습니다."),
@@ -21,7 +21,9 @@ public enum ShowErrorCode implements StatusCode {
 	OCR_NOT_LATEST_SHOW(HttpStatus.EXPECTATION_FAILED, "OCR로 추출한 날짜가 공연의 최신 날짜가 아닙니다."),
 	OBJECT_TRANSFORMATION_FAILD(HttpStatus.EXPECTATION_FAILED, "객체 변환에 실패했습니다. (JSON -> RegisterShowRequest)"),
 	OCR_NOT_EQUAL_TEAMS_AND_POSTER_NUMBERS(HttpStatus.EXPECTATION_FAILED, "팀의 수와 포스터의 수가 일치하지 않습니다."),
-	OCR_IMAGE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 url를 파일로 변환하는데 실패했습니다.");
+	OCR_IMAGE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 url를 파일로 변환하는데 실패했습니다."),
+	OCR_NOT_FOUND_DATE(HttpStatus.INTERNAL_SERVER_ERROR, "OCR로 추출한 텍스트에 공연 날짜가 없습니다."),
+	OCR_NOT_FOUND_MATCHED_TEMPLATE(HttpStatus.INTERNAL_SERVER_ERROR, "OCR에 등록된 템플릿과 일치하는 템플릿이 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/be/src/main/java/kr/codesquad/jazzmeet/global/util/CustomLocalDate.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/global/util/CustomLocalDate.java
@@ -3,6 +3,8 @@ package kr.codesquad.jazzmeet.global.util;
 import java.time.LocalDate;
 import java.time.Month;
 
+import kr.codesquad.jazzmeet.show.util.TextParser;
+
 public class CustomLocalDate {
 
 	public static LocalDate of(String text) {

--- a/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/image/service/ImageService.java
@@ -1,13 +1,22 @@
 package kr.codesquad.jazzmeet.image.service;
 
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URL;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+
+import javax.imageio.ImageIO;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import kr.codesquad.jazzmeet.global.error.CustomException;
 import kr.codesquad.jazzmeet.global.error.statuscode.ImageErrorCode;
+import kr.codesquad.jazzmeet.global.util.CustomMultipartFile;
 import kr.codesquad.jazzmeet.image.dto.response.ImageCreateResponse;
 import kr.codesquad.jazzmeet.image.dto.response.ImageSaveResponse;
 import kr.codesquad.jazzmeet.image.entity.Image;
@@ -15,8 +24,11 @@ import kr.codesquad.jazzmeet.image.entity.ImageStatus;
 import kr.codesquad.jazzmeet.image.mapper.ImageMapper;
 import kr.codesquad.jazzmeet.image.repository.ImageQueryRepository;
 import kr.codesquad.jazzmeet.image.repository.ImageRepository;
+import kr.codesquad.jazzmeet.image.repository.S3ImageHandler;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
@@ -24,6 +36,7 @@ public class ImageService {
 
 	private final ImageRepository imageRepository;
 	private final ImageQueryRepository imageQueryRepository;
+	private final S3ImageHandler s3ImageHandler;
 
 	@Transactional
 	public ImageCreateResponse saveImages(List<String> imageUrls, ImageStatus imageStatus) {
@@ -67,5 +80,37 @@ public class ImageService {
 	@Transactional
 	public void deleteImagesByUrls(List<String> urls) {
 		imageQueryRepository.deleteAllInUrls(urls);
+	}
+
+	public List<Long> uploadPosters(List<String> posterUrls) {
+		// Image 가져오기
+		List<MultipartFile> multipartFiles = convertImageUrlToMultipartFile(posterUrls);
+		// S3에 사진 저장
+		List<String> uploadedImageUrls = s3ImageHandler.uploadImages(multipartFiles);
+		// DB에 저장
+		ImageStatus imageStatus = ImageStatus.REGISTERED;
+		ImageCreateResponse imageCreateResponse = saveImages(uploadedImageUrls, imageStatus);
+
+		return imageCreateResponse.images().stream().map(ImageSaveResponse::id).toList();
+	}
+
+	private List<MultipartFile> convertImageUrlToMultipartFile(List<String> imageUrls) {
+		List<MultipartFile> multipartFiles = new ArrayList<>();
+		for (int i = 0; i < imageUrls.size(); i++) {
+			ByteArrayOutputStream out = new ByteArrayOutputStream();
+			try {
+				BufferedImage image = ImageIO.read(new URL(imageUrls.get(i)));
+				ImageIO.write(image, "jpeg", out);
+			} catch (IOException e) {
+				log.error("IO Error", e);
+				return null;
+			}
+			byte[] bytes = out.toByteArray();
+			CustomMultipartFile customMultipartFile = new CustomMultipartFile(bytes, "image" + i,
+				"posterImage" + i + ".jpeg",
+				"jpeg", bytes.length);
+			multipartFiles.add(customMultipartFile);
+		}
+		return multipartFiles;
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
@@ -52,6 +52,7 @@ public class OcrHandler {
 	public static final String INFER_TEXT = "inferText";
 	private static final String SCHEDULE = "스케줄";
 	private static final int ENTRY55_RUNTIME = 55;
+	private static final String NOT_FOUND_MATCHED_TEMPLATE = "not found matched template";
 
 	@Value("${naver.clova.endpoint}")
 	private String apiURL;
@@ -63,8 +64,27 @@ public class OcrHandler {
 	@Transactional
 	public List<RegisterShowRequest> getShows(String venueName, String scheduleUrl, List<String> posterUrls,
 		LocalDate latestShowDate) {
+		try {
+			return getShowRequests(venueName, scheduleUrl, posterUrls, latestShowDate);
+
+		} catch (CustomException e) {
+			if (e.getStatusCode().equals(ShowErrorCode.OCR_NOT_FOUND_MATCHED_TEMPLATE)) {
+				// 크롤링 했던 다음 이미지로 공연 스케줄 OCR 요청 재시도
+				String newScheduleUrl = posterUrls.get(0);
+				posterUrls.remove(0);
+
+				return getShowRequests(venueName, newScheduleUrl, posterUrls, latestShowDate);
+			}
+		}
+
+		throw new CustomException(ShowErrorCode.OCR_REQUEST_FAILED);
+	}
+
+	private List<RegisterShowRequest> getShowRequests(String venueName, String scheduleUrl, List<String> posterUrls,
+		LocalDate latestShowDate) {
 		StringBuffer response = sendRequest(scheduleUrl);
 		List<RegisterShowRequest> requests = toRegisterShowRequest(venueName, response, posterUrls, latestShowDate);
+
 		if (requests.isEmpty()) {
 			throw new CustomException(ShowErrorCode.OBJECT_TRANSFORMATION_FAILD);
 		}
@@ -128,15 +148,24 @@ public class OcrHandler {
 		JSONTokener tokener = new JSONTokener(response.toString());
 		JSONObject object = new JSONObject(tokener);
 		JSONObject images = object.getJSONArray("images").getJSONObject(0);
+		// 공연장 템플릿(OCR)이 적용되지 않았으면 에러를 반환하고, 크롤링으로 가져왔던 다음 이미지로 OCR 요청을 다시 시도한다.
+		String responseMessage = images.get("message").toString();
+		if (responseMessage.contains(NOT_FOUND_MATCHED_TEMPLATE)) {
+			throw new CustomException(ShowErrorCode.OCR_NOT_FOUND_MATCHED_TEMPLATE);
+		}
 		// 일치하지 않는 공연장 템플릿(OCR)이 적용되었으면 에러를 반환한다.
 		String templateName = images.getJSONObject("matchedTemplate").get(NAME).toString();
+		System.out.println("templateName: " + templateName);
 		String venueNameSchedule = venueName + " " + SCHEDULE;
+		System.out.println("venueNameSchedule: " + venueNameSchedule);
 		if (!templateName.equals(venueNameSchedule)) {
 			throw new CustomException(ShowErrorCode.OCR_NOT_MATCHED_VENUE_AND_IMAGE);
 		}
 
 		JSONArray fields = images.getJSONArray("fields");
 		LocalDate firstShowDate = null;
+		// 공연 스케줄 - 그 주의 시작 공연 날짜, 끝 공연 날짜
+		String showFirstLastDateText = null;
 		// 아티스트의 이름, 상세(=연주자들)
 		String teamsText = null;
 		// response로 받은 공연 데이터가 최신 데이터인지 확인하는 flag
@@ -145,19 +174,31 @@ public class OcrHandler {
 			JSONObject jsonObject = fields.getJSONObject(i);
 			// 처음 공연 날짜 , 마지막 공연 날짜
 			if (jsonObject.get(NAME).equals(SHOW_DATE)) {
-				String showFirstLastDateText = jsonObject.get(INFER_TEXT).toString();
-				firstShowDate = makeShowStartLocalDate(showFirstLastDateText);
-				// response로 받은 공연 시작 날짜가, 공연장에 등록 된 가장 최신 공연 날짜보다 뒤라면
-				if (latestShowDate == null || firstShowDate.isAfter(latestShowDate)) {
-					// 최신 데이터로 flag 변경.
-					isShowDataAfterLatestShow = true;
-				}
+				showFirstLastDateText = jsonObject.get(INFER_TEXT).toString();
 			}
 
 			// 아티스트 목록
 			if (jsonObject.get(NAME).equals(TEAMS)) {
 				teamsText = jsonObject.get(INFER_TEXT).toString();
 			}
+		}
+
+		// 공연 날짜 필드에 값이 없으면, "팀 정보" 필드로 인식 되었을 수 있다.
+		if (showFirstLastDateText == null || showFirstLastDateText.isBlank()) {
+			// 팀 정보에서 개행 문자 기준, 첫 줄을 공연 날짜에 넣어준다.
+			showFirstLastDateText = teamsText.split("\n")[0];
+			// 공연 날짜에 넣어준 줄(newLine)을 제외한 나머지 텍스트를 팀 정보에 적용한다.
+			int newLineIndex = teamsText.indexOf("\n");
+			teamsText = teamsText.substring(newLineIndex + 1);
+			// 텍스트에 공연 날짜가 섞여있을 수 있기 때문에 공연 날짜만 추출한다.
+			showFirstLastDateText = TextParser.findDate(showFirstLastDateText);
+		}
+
+		firstShowDate = makeShowStartLocalDate(showFirstLastDateText);
+		// response로 받은 공연 시작 날짜가, 공연장에 등록 된 가장 최신 공연 날짜보다 뒤라면
+		if (latestShowDate == null || firstShowDate.isAfter(latestShowDate)) {
+			// 최신 데이터로 flag 변경.
+			isShowDataAfterLatestShow = true;
 		}
 
 		if (firstShowDate == null) {
@@ -189,11 +230,12 @@ public class OcrHandler {
 		String[] splitedArtists = teams.split("\n");
 		LocalDate showDate = firstShowDate;
 		boolean isSatFirstShow = false;
-		List<Long> posterIds = uploadPosters(posterUrls);
 
-		if ((splitedArtists.length / 2) != posterIds.size()) { // 팀(+설명)과 포스터의 수가 맞지 않으면 예외 발생
+		if ((splitedArtists.length / 2) != posterUrls.size()) { // 팀(+설명)과 포스터의 수가 맞지 않으면 예외 발생
 			throw new CustomException(ShowErrorCode.OCR_NOT_EQUAL_TEAMS_AND_POSTER_NUMBERS);
 		}
+
+		List<Long> posterIds = uploadPosters(posterUrls);
 
 		for (int i = 0; i < splitedArtists.length; i += 2) {
 			String teamName = splitedArtists[i];
@@ -202,7 +244,8 @@ public class OcrHandler {
 			Long posterId = posterIds.get(i / 2);
 
 			if (isSatFirstShow) { // 토요일만 스케줄이 다르다.
-				LocalDateTime saturdayShowStartTime = LocalDateTime.of(showDate, LocalTime.of(16, 20));
+				// 토요일 첫번째 공연(Trio) 시간
+				LocalDateTime saturdayShowStartTime = LocalDateTime.of(showDate, LocalTime.of(15, 50));
 				LocalDateTime saturdayShowEndTime = saturdayShowStartTime.plusMinutes(ENTRY55_RUNTIME);
 				RegisterShowRequest request = ShowMapper.INSTANCE.toRegisterShowRequest(teamName, teamMusician,
 					posterId, saturdayShowStartTime, saturdayShowEndTime);
@@ -276,9 +319,9 @@ public class OcrHandler {
 	}
 
 	private LocalTime setFirstShowTime(DayOfWeek dayOfWeek) {
-		// 토요일 첫번째 공연 시작 시간
+		// 토요일 두번째(Special GIG - 1) 공연 시작 시간
 		if (dayOfWeek.equals(DayOfWeek.SATURDAY)) {
-			return LocalTime.of(19, 15);
+			return LocalTime.of(18, 45);
 		}
 		// 일요일 첫번째 공연 시작 시간
 		if (dayOfWeek.equals(DayOfWeek.SUNDAY)) {
@@ -290,12 +333,16 @@ public class OcrHandler {
 	}
 
 	private LocalTime setSecondShowTime(DayOfWeek dayOfWeek) {
+		// 토요일 세번째(Special GIG - 2) 공연 시작 시간
+		if (dayOfWeek.equals(DayOfWeek.SATURDAY)) {
+			return LocalTime.of(21, 10);
+		}
 		// 일요일 두번째 공연 시작 시간
 		if (dayOfWeek.equals(DayOfWeek.SUNDAY)) {
 			return LocalTime.of(20, 40);
 		}
 
-		// 평일 + 토요일 두번째 공연 시작 시간 (월~토)
+		// 평일 두번째 공연 시작 시간 (월~금)
 		return LocalTime.of(21, 40);
 	}
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
@@ -30,7 +30,6 @@ import kr.codesquad.jazzmeet.global.error.CustomException;
 import kr.codesquad.jazzmeet.global.error.statuscode.ShowErrorCode;
 import kr.codesquad.jazzmeet.global.util.CustomLocalDate;
 import kr.codesquad.jazzmeet.global.util.CustomMultipartFile;
-import kr.codesquad.jazzmeet.global.util.TextParser;
 import kr.codesquad.jazzmeet.image.dto.response.ImageCreateResponse;
 import kr.codesquad.jazzmeet.image.dto.response.ImageSaveResponse;
 import kr.codesquad.jazzmeet.image.entity.ImageStatus;
@@ -38,6 +37,7 @@ import kr.codesquad.jazzmeet.image.repository.S3ImageHandler;
 import kr.codesquad.jazzmeet.image.service.ImageService;
 import kr.codesquad.jazzmeet.show.dto.request.RegisterShowRequest;
 import kr.codesquad.jazzmeet.show.mapper.ShowMapper;
+import kr.codesquad.jazzmeet.show.util.TextParser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
@@ -155,9 +155,7 @@ public class OcrHandler {
 		}
 		// 일치하지 않는 공연장 템플릿(OCR)이 적용되었으면 에러를 반환한다.
 		String templateName = images.getJSONObject("matchedTemplate").get(NAME).toString();
-		System.out.println("templateName: " + templateName);
 		String venueNameSchedule = venueName + " " + SCHEDULE;
-		System.out.println("venueNameSchedule: " + venueNameSchedule);
 		if (!templateName.equals(venueNameSchedule)) {
 			throw new CustomException(ShowErrorCode.OCR_NOT_MATCHED_VENUE_AND_IMAGE);
 		}

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/OcrHandler.java
@@ -5,28 +5,20 @@ import java.io.DataOutputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.json.JSONTokener;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import kr.codesquad.jazzmeet.global.error.CustomException;
 import kr.codesquad.jazzmeet.global.error.statuscode.ShowErrorCode;
-import kr.codesquad.jazzmeet.global.util.CustomLocalDate;
-import kr.codesquad.jazzmeet.image.service.ImageService;
 import kr.codesquad.jazzmeet.show.dto.request.RegisterShowRequest;
-import kr.codesquad.jazzmeet.show.mapper.ShowMapper;
-import kr.codesquad.jazzmeet.show.util.TextParser;
+import kr.codesquad.jazzmeet.show.util.ResponseParser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,19 +27,12 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class OcrHandler {
 
-	public static final String SHOW_DATE = "Show Date";
-	public static final String NAME = "name";
-	public static final String TEAMS = "Teams";
-	public static final String INFER_TEXT = "inferText";
-	private static final String SCHEDULE = "스케줄";
-	private static final int ENTRY55_RUNTIME = 55;
-	private static final String NOT_FOUND_MATCHED_TEMPLATE = "not found matched template";
-
 	@Value("${naver.clova.endpoint}")
 	private String apiURL;
 	@Value("${naver.clova.secretKey}")
 	private String secretKey;
-	private final ImageService imageService;
+
+	private final ResponseParser responseParser;
 
 	@Transactional
 	public List<RegisterShowRequest> getShows(String venueName, String scheduleUrl, List<String> posterUrls,
@@ -65,13 +50,14 @@ public class OcrHandler {
 			}
 		}
 
-		throw new CustomException(ShowErrorCode.OCR_REQUEST_FAILED);
+		throw new CustomException(ShowErrorCode.OCR_FAILED);
 	}
 
 	private List<RegisterShowRequest> getShowRequests(String venueName, String scheduleUrl, List<String> posterUrls,
 		LocalDate latestShowDate) {
 		StringBuffer response = sendRequest(scheduleUrl);
-		List<RegisterShowRequest> requests = toRegisterShowRequest(venueName, response, posterUrls, latestShowDate);
+		List<RegisterShowRequest> requests = responseParser.toRegisterShowRequest(venueName, response, posterUrls,
+			latestShowDate);
 
 		if (requests.isEmpty()) {
 			throw new CustomException(ShowErrorCode.OBJECT_TRANSFORMATION_FAILD);
@@ -126,178 +112,8 @@ public class OcrHandler {
 			log.debug("OCR Response: {}", response);
 			return response;
 		} catch (Exception e) {
-			throw new CustomException(ShowErrorCode.OCR_REQUEST_FAILED);
+			throw new CustomException(ShowErrorCode.OCR_FAILED);
 		}
-	}
-
-	private List<RegisterShowRequest> toRegisterShowRequest(String venueName, StringBuffer response,
-		List<String> posterUrls, LocalDate latestShowDate) {
-		// JSON 파싱
-		JSONTokener tokener = new JSONTokener(response.toString());
-		JSONObject object = new JSONObject(tokener);
-		JSONObject images = object.getJSONArray("images").getJSONObject(0);
-		// 공연장 템플릿(OCR)이 적용되지 않았으면 에러를 반환하고, 크롤링으로 가져왔던 다음 이미지로 OCR 요청을 다시 시도한다.
-		String responseMessage = images.get("message").toString();
-		if (responseMessage.contains(NOT_FOUND_MATCHED_TEMPLATE)) {
-			throw new CustomException(ShowErrorCode.OCR_NOT_FOUND_MATCHED_TEMPLATE);
-		}
-		// 일치하지 않는 공연장 템플릿(OCR)이 적용되었으면 에러를 반환한다.
-		String templateName = images.getJSONObject("matchedTemplate").get(NAME).toString();
-		String venueNameSchedule = venueName + " " + SCHEDULE;
-		if (!templateName.equals(venueNameSchedule)) {
-			throw new CustomException(ShowErrorCode.OCR_NOT_MATCHED_VENUE_AND_IMAGE);
-		}
-
-		JSONArray fields = images.getJSONArray("fields");
-		LocalDate firstShowDate = null;
-		// 공연 스케줄 - 그 주의 시작 공연 날짜, 끝 공연 날짜
-		String showFirstLastDateText = null;
-		// 아티스트의 이름, 상세(=연주자들)
-		String teamsText = null;
-		// response로 받은 공연 데이터가 최신 데이터인지 확인하는 flag
-		boolean isShowDataAfterLatestShow = false;
-		for (int i = 0; i < fields.length(); i++) {
-			JSONObject jsonObject = fields.getJSONObject(i);
-			// 처음 공연 날짜 , 마지막 공연 날짜
-			if (jsonObject.get(NAME).equals(SHOW_DATE)) {
-				showFirstLastDateText = jsonObject.get(INFER_TEXT).toString();
-			}
-
-			// 아티스트 목록
-			if (jsonObject.get(NAME).equals(TEAMS)) {
-				teamsText = jsonObject.get(INFER_TEXT).toString();
-			}
-		}
-
-		// 공연 날짜 필드에 값이 없으면, "팀 정보" 필드로 인식 되었을 수 있다.
-		if (showFirstLastDateText == null || showFirstLastDateText.isBlank()) {
-			// 팀 정보에서 개행 문자 기준, 첫 줄을 공연 날짜에 넣어준다.
-			showFirstLastDateText = teamsText.split("\n")[0];
-			// 공연 날짜에 넣어준 줄(newLine)을 제외한 나머지 텍스트를 팀 정보에 적용한다.
-			int newLineIndex = teamsText.indexOf("\n");
-			teamsText = teamsText.substring(newLineIndex + 1);
-			// 텍스트에 공연 날짜가 섞여있을 수 있기 때문에 공연 날짜만 추출한다.
-			showFirstLastDateText = TextParser.findDate(showFirstLastDateText);
-		}
-
-		firstShowDate = makeShowStartLocalDate(showFirstLastDateText);
-		// response로 받은 공연 시작 날짜가, 공연장에 등록 된 가장 최신 공연 날짜보다 뒤라면
-		if (latestShowDate == null || firstShowDate.isAfter(latestShowDate)) {
-			// 최신 데이터로 flag 변경.
-			isShowDataAfterLatestShow = true;
-		}
-
-		if (firstShowDate == null) {
-			throw new CustomException(ShowErrorCode.OCR_EXTRACTION_FAILED_SHOW_DATE);
-		}
-
-		if (teamsText == null) {
-			throw new CustomException(ShowErrorCode.OCR_EXTRACTION_FAILED_ARTISTS_AND_DETAILS);
-		}
-
-		if (!isShowDataAfterLatestShow) {
-			throw new CustomException(ShowErrorCode.OCR_NOT_LATEST_SHOW);
-		}
-
-		// response가 최신 데이터라면 파싱해서 공연 등록 request로 만든다.
-		return makeRegisterShowRequest(firstShowDate, teamsText, posterUrls);
-	}
-
-	private LocalDate makeShowStartLocalDate(String showStartEndDateText) {
-		boolean isStartShow = true; // 시작 공연 파싱
-		String showDateText = TextParser.parseDate(showStartEndDateText, isStartShow);
-
-		return CustomLocalDate.of(showDateText);
-	}
-
-	private List<RegisterShowRequest> makeRegisterShowRequest(LocalDate firstShowDate, String teams,
-		List<String> posterUrls) {
-		List<RegisterShowRequest> requests = new ArrayList<>();
-		String[] splitedArtists = teams.split("\n");
-		LocalDate showDate = firstShowDate;
-		boolean isSatFirstShow = false;
-
-		if ((splitedArtists.length / 2) != posterUrls.size()) { // 팀(+설명)과 포스터의 수가 맞지 않으면 예외 발생
-			throw new CustomException(ShowErrorCode.OCR_NOT_EQUAL_TEAMS_AND_POSTER_NUMBERS);
-		}
-
-		List<Long> posterIds = imageService.uploadPosters(posterUrls);
-
-		for (int i = 0; i < splitedArtists.length; i += 2) {
-			String teamName = splitedArtists[i];
-			String teamMusician = splitedArtists[i + 1];
-			// 포스터 index는 순차적으로 올라간다.
-			Long posterId = posterIds.get(i / 2);
-
-			if (isSatFirstShow) { // 토요일만 스케줄이 다르다.
-				// 토요일 첫번째 공연(Trio) 시간
-				LocalDateTime saturdayShowStartTime = LocalDateTime.of(showDate, LocalTime.of(15, 50));
-				LocalDateTime saturdayShowEndTime = saturdayShowStartTime.plusMinutes(ENTRY55_RUNTIME);
-				RegisterShowRequest request = ShowMapper.INSTANCE.toRegisterShowRequest(teamName, teamMusician,
-					posterId, saturdayShowStartTime, saturdayShowEndTime);
-
-				requests.add(request);
-				// 첫번째 공연 플래그 변경
-				isSatFirstShow = false;
-				continue;
-			}
-
-			// 공연 시작 시간 설정
-			LocalTime firstShowStartTime = setFirstShowTime(showDate.getDayOfWeek());
-			LocalTime secondShowStartTime = setSecondShowTime(showDate.getDayOfWeek());
-
-			// 공연 날짜 + 시간(시작, 끝) 설정
-			LocalDateTime firstShowStartDateTime = LocalDateTime.of(showDate, firstShowStartTime);
-			LocalDateTime firstShowEndTime = firstShowStartDateTime.plusMinutes(ENTRY55_RUNTIME);
-			LocalDateTime secondShowStartDateTime = LocalDateTime.of(showDate, secondShowStartTime);
-			LocalDateTime secondShowEndTime = secondShowStartDateTime.plusMinutes(ENTRY55_RUNTIME);
-
-			RegisterShowRequest firstShowRequest = ShowMapper.INSTANCE.toRegisterShowRequest(teamName, teamMusician,
-				posterId, firstShowStartDateTime, firstShowEndTime);
-			RegisterShowRequest secondShowRequest = ShowMapper.INSTANCE.toRegisterShowRequest(teamName, teamMusician,
-				posterId, secondShowStartDateTime, secondShowEndTime);
-
-			requests.add(firstShowRequest);
-			requests.add(secondShowRequest);
-
-			// 다음 날로 변경
-			showDate = showDate.plusDays(1);
-
-			// 토요일 공연이면 첫번째 공연 플래그를 변경해준다.
-			if (showDate.getDayOfWeek().equals(DayOfWeek.SATURDAY)) {
-				isSatFirstShow = true;
-			}
-		}
-
-		return requests;
-	}
-
-	private LocalTime setFirstShowTime(DayOfWeek dayOfWeek) {
-		// 토요일 두번째(Special GIG - 1) 공연 시작 시간
-		if (dayOfWeek.equals(DayOfWeek.SATURDAY)) {
-			return LocalTime.of(18, 45);
-		}
-		// 일요일 첫번째 공연 시작 시간
-		if (dayOfWeek.equals(DayOfWeek.SUNDAY)) {
-			return LocalTime.of(18, 30);
-		}
-
-		// 평일 첫번째 공연 시작 시간 (월~금)
-		return LocalTime.of(19, 30);
-	}
-
-	private LocalTime setSecondShowTime(DayOfWeek dayOfWeek) {
-		// 토요일 세번째(Special GIG - 2) 공연 시작 시간
-		if (dayOfWeek.equals(DayOfWeek.SATURDAY)) {
-			return LocalTime.of(21, 10);
-		}
-		// 일요일 두번째 공연 시작 시간
-		if (dayOfWeek.equals(DayOfWeek.SUNDAY)) {
-			return LocalTime.of(20, 40);
-		}
-
-		// 평일 두번째 공연 시작 시간 (월~금)
-		return LocalTime.of(21, 40);
 	}
 
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
@@ -10,7 +10,6 @@ import java.util.List;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -19,8 +18,8 @@ import org.springframework.util.ObjectUtils;
 import kr.codesquad.jazzmeet.global.error.CustomException;
 import kr.codesquad.jazzmeet.global.error.statuscode.ShowErrorCode;
 import kr.codesquad.jazzmeet.global.util.CustomLocalDate;
-import kr.codesquad.jazzmeet.global.util.TextParser;
 import kr.codesquad.jazzmeet.global.util.WebDriverUtil;
+import kr.codesquad.jazzmeet.show.util.TextParser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
@@ -94,7 +93,7 @@ public class WebCrawler {
 			// 	"https://www.instagram.com/accounts/onetap/?next=%2F")); // 로그인 완료 후 url 전환하기까지 대기
 			driver.get(venueInstagramUrl); // 공연장 instagram url로 이동
 			Thread.sleep(2000); // url 이동 대기 시간 (게시글)
-			
+
 			driver.findElements(
 					By.className("_aagw")) // 게시물 선택
 				.get(0).click();
@@ -110,6 +109,11 @@ public class WebCrawler {
 				String articleText = driver.findElements(
 						By.className("_a9zs"))
 					.get(0).getText();
+
+				// 공연 날짜(=숫자)가 존재하는 Line을 찾는다.
+				articleText = TextParser.findDateLine(articleText);
+
+				log.debug("게시물 텍스트 내용: {}", articleText);
 				if (!articleText.contains("라인업")) { // 스케줄 키워드가 포함되어있지 않으면 다음 게시물을 탐색한다.
 					driver.findElements(By.className(NEXT_ARTICLE_BUTTON_CLASS_NAME))
 						.get(nextBtnIndex)

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
@@ -2,7 +2,6 @@ package kr.codesquad.jazzmeet.show.repository;
 
 import java.time.Duration;
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -182,17 +181,6 @@ public class WebCrawler {
 		}
 
 		return imageUrls;
-	}
-
-	private boolean isEqualsToDefaultShowDayCount(String articleText) {
-		// articleText = "02.07 - 02.12 아티스트 라인업입니다!"
-		String startDateText = TextParser.parseDate(articleText, true);
-		LocalDate startDate = CustomLocalDate.of(startDateText);
-		String endDateText = TextParser.parseDate(articleText, false);
-		LocalDate endDate = CustomLocalDate.of(endDateText);
-		long daysDiff = ChronoUnit.DAYS.between(startDate, endDate) + 1;
-
-		return DEFAULT_SHOW_DAY_COUNT == daysDiff;
 	}
 
 	private boolean isNewShowDate(String articleText, LocalDate latestShowDate) {

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/repository/WebCrawler.java
@@ -130,17 +130,11 @@ public class WebCrawler {
 
 				// 오른쪽 화살표로 img 탐색.
 				// 이벤트가 존재하는 주(week)는, 공연 날짜가 추가되어 2번째 img에 스케줄표가 위치해 있다.
+				// 이벤트가 없는 기본(default) 주(week)는, 3번째 img에 스케줄표가 위치해 있다.
 				driver.findElements(By.className(NEXT_PHOTO_BUTTON_CLASS_NAME))
 					.get(0)
 					.click();
-				// 이벤트가 없는 기본(default) 주(week)는, 3번째 img에 스케줄표가 위치해 있다.
-				// 공연 일(day)수가 기본(default) 일수와 동일한지 확인.
-				boolean isEqualsToDefaultShowDayCount = isEqualsToDefaultShowDayCount(articleText);
-				if (isEqualsToDefaultShowDayCount) {
-					driver.findElements(By.className(NEXT_PHOTO_BUTTON_CLASS_NAME))
-						.get(0)
-						.click();
-				}
+
 				Thread.sleep(2000); // 대기 시간
 
 				// entry55(default Schedule)인 경우 3번째 img가 주간 공연 스케줄, 4번째부터 공연 poster가 나열된다.
@@ -150,13 +144,6 @@ public class WebCrawler {
 				// div._aagu _aa20 _aato > div._aagv > img .get(0)
 				// 클릭해서 이동 1, 2
 				String imageUrl = img.getAttribute("src");
-				log.debug("Instagram Image URL: {}", imageUrl);
-				if (!isEqualsToDefaultShowDayCount) {
-					// 오른쪽 화살표를 클릭해 다음 이미지로 넘어간다.
-					driver.findElements(By.className(NEXT_PHOTO_BUTTON_CLASS_NAME))
-						.get(0)
-						.click();
-				}
 
 				List<String> posterImgUrls = new ArrayList<>();
 				while (true) {

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/util/ResponseParser.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/util/ResponseParser.java
@@ -1,0 +1,206 @@
+package kr.codesquad.jazzmeet.show.util;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.springframework.stereotype.Component;
+
+import kr.codesquad.jazzmeet.global.error.CustomException;
+import kr.codesquad.jazzmeet.global.error.statuscode.ShowErrorCode;
+import kr.codesquad.jazzmeet.global.util.CustomLocalDate;
+import kr.codesquad.jazzmeet.image.service.ImageService;
+import kr.codesquad.jazzmeet.show.dto.request.RegisterShowRequest;
+import kr.codesquad.jazzmeet.show.mapper.ShowMapper;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class ResponseParser {
+
+	public static final String SHOW_DATE = "Show Date";
+	public static final String NAME = "name";
+	public static final String TEAMS = "Teams";
+	public static final String INFER_TEXT = "inferText";
+	private static final String SCHEDULE = "스케줄";
+	private static final int ENTRY55_RUNTIME = 55;
+	private static final String NOT_FOUND_MATCHED_TEMPLATE = "not found matched template";
+
+	private final ImageService imageService;
+
+	public List<RegisterShowRequest> toRegisterShowRequest(String venueName, StringBuffer response,
+		List<String> posterUrls, LocalDate latestShowDate) {
+		// JSON 파싱
+		JSONTokener tokener = new JSONTokener(response.toString());
+		JSONObject object = new JSONObject(tokener);
+		JSONObject images = object.getJSONArray("images").getJSONObject(0);
+		// 공연장 템플릿(OCR)이 적용되지 않았으면 에러를 반환하고, 크롤링으로 가져왔던 다음 이미지로 OCR 요청을 다시 시도한다.
+		String responseMessage = images.get("message").toString();
+		if (responseMessage.contains(NOT_FOUND_MATCHED_TEMPLATE)) {
+			throw new CustomException(ShowErrorCode.OCR_NOT_FOUND_MATCHED_TEMPLATE);
+		}
+		// 일치하지 않는 공연장 템플릿(OCR)이 적용되었으면 에러를 반환한다.
+		String templateName = images.getJSONObject("matchedTemplate").get(NAME).toString();
+		String venueNameSchedule = venueName + " " + SCHEDULE;
+		if (!templateName.equals(venueNameSchedule)) {
+			throw new CustomException(ShowErrorCode.OCR_NOT_MATCHED_VENUE_AND_IMAGE);
+		}
+
+		JSONArray fields = images.getJSONArray("fields");
+		LocalDate firstShowDate = null;
+		// 공연 스케줄 - 그 주의 시작 공연 날짜, 끝 공연 날짜
+		String showFirstLastDateText = null;
+		// 아티스트의 이름, 상세(=연주자들)
+		String teamsText = null;
+		// response로 받은 공연 데이터가 최신 데이터인지 확인하는 flag
+		boolean isShowDataAfterLatestShow = false;
+		for (int i = 0; i < fields.length(); i++) {
+			JSONObject jsonObject = fields.getJSONObject(i);
+			// 처음 공연 날짜 , 마지막 공연 날짜
+			if (jsonObject.get(NAME).equals(SHOW_DATE)) {
+				showFirstLastDateText = jsonObject.get(INFER_TEXT).toString();
+			}
+
+			// 아티스트 목록
+			if (jsonObject.get(NAME).equals(TEAMS)) {
+				teamsText = jsonObject.get(INFER_TEXT).toString();
+			}
+		}
+
+		// 공연 날짜 필드에 값이 없으면, "팀 정보" 필드로 인식 되었을 수 있다.
+		if (showFirstLastDateText == null || showFirstLastDateText.isBlank()) {
+			// 팀 정보에서 개행 문자 기준, 첫 줄을 공연 날짜에 넣어준다.
+			showFirstLastDateText = teamsText.split("\n")[0];
+			// 공연 날짜에 넣어준 줄(newLine)을 제외한 나머지 텍스트를 팀 정보에 적용한다.
+			int newLineIndex = teamsText.indexOf("\n");
+			teamsText = teamsText.substring(newLineIndex + 1);
+			// 텍스트에 공연 날짜가 섞여있을 수 있기 때문에 공연 날짜만 추출한다.
+			showFirstLastDateText = TextParser.findDate(showFirstLastDateText);
+		}
+
+		firstShowDate = makeShowStartLocalDate(showFirstLastDateText);
+		// response로 받은 공연 시작 날짜가, 공연장에 등록 된 가장 최신 공연 날짜보다 뒤라면
+		if (latestShowDate == null || firstShowDate.isAfter(latestShowDate)) {
+			// 최신 데이터로 flag 변경.
+			isShowDataAfterLatestShow = true;
+		}
+
+		if (firstShowDate == null) {
+			throw new CustomException(ShowErrorCode.OCR_EXTRACTION_FAILED_SHOW_DATE);
+		}
+
+		if (teamsText == null) {
+			throw new CustomException(ShowErrorCode.OCR_EXTRACTION_FAILED_ARTISTS_AND_DETAILS);
+		}
+
+		if (!isShowDataAfterLatestShow) {
+			throw new CustomException(ShowErrorCode.OCR_NOT_LATEST_SHOW);
+		}
+
+		// response가 최신 데이터라면 파싱해서 공연 등록 request로 만든다.
+		return makeRegisterShowRequest(firstShowDate, teamsText, posterUrls);
+	}
+
+	private LocalDate makeShowStartLocalDate(String showStartEndDateText) {
+		boolean isStartShow = true; // 시작 공연 파싱
+		String showDateText = TextParser.parseDate(showStartEndDateText, isStartShow);
+
+		return CustomLocalDate.of(showDateText);
+	}
+
+	private List<RegisterShowRequest> makeRegisterShowRequest(LocalDate firstShowDate, String teams,
+		List<String> posterUrls) {
+		List<RegisterShowRequest> requests = new ArrayList<>();
+		String[] splitedArtists = teams.split("\n");
+		LocalDate showDate = firstShowDate;
+		boolean isSatFirstShow = false;
+
+		if ((splitedArtists.length / 2) != posterUrls.size()) { // 팀(+설명)과 포스터의 수가 맞지 않으면 예외 발생
+			throw new CustomException(ShowErrorCode.OCR_NOT_EQUAL_TEAMS_AND_POSTER_NUMBERS);
+		}
+
+		List<Long> posterIds = imageService.uploadPosters(posterUrls);
+
+		for (int i = 0; i < splitedArtists.length; i += 2) {
+			String teamName = splitedArtists[i];
+			String teamMusician = splitedArtists[i + 1];
+			// 포스터 index는 순차적으로 올라간다.
+			Long posterId = posterIds.get(i / 2);
+
+			if (isSatFirstShow) { // 토요일만 스케줄이 다르다.
+				// 토요일 첫번째 공연(Trio) 시간
+				LocalDateTime saturdayShowStartTime = LocalDateTime.of(showDate, LocalTime.of(15, 50));
+				LocalDateTime saturdayShowEndTime = saturdayShowStartTime.plusMinutes(ENTRY55_RUNTIME);
+				RegisterShowRequest request = ShowMapper.INSTANCE.toRegisterShowRequest(teamName, teamMusician,
+					posterId, saturdayShowStartTime, saturdayShowEndTime);
+
+				requests.add(request);
+				// 첫번째 공연 플래그 변경
+				isSatFirstShow = false;
+				continue;
+			}
+
+			// 공연 시작 시간 설정
+			LocalTime firstShowStartTime = setFirstShowTime(showDate.getDayOfWeek());
+			LocalTime secondShowStartTime = setSecondShowTime(showDate.getDayOfWeek());
+
+			// 공연 날짜 + 시간(시작, 끝) 설정
+			LocalDateTime firstShowStartDateTime = LocalDateTime.of(showDate, firstShowStartTime);
+			LocalDateTime firstShowEndTime = firstShowStartDateTime.plusMinutes(ENTRY55_RUNTIME);
+			LocalDateTime secondShowStartDateTime = LocalDateTime.of(showDate, secondShowStartTime);
+			LocalDateTime secondShowEndTime = secondShowStartDateTime.plusMinutes(ENTRY55_RUNTIME);
+
+			RegisterShowRequest firstShowRequest = ShowMapper.INSTANCE.toRegisterShowRequest(teamName, teamMusician,
+				posterId, firstShowStartDateTime, firstShowEndTime);
+			RegisterShowRequest secondShowRequest = ShowMapper.INSTANCE.toRegisterShowRequest(teamName, teamMusician,
+				posterId, secondShowStartDateTime, secondShowEndTime);
+
+			requests.add(firstShowRequest);
+			requests.add(secondShowRequest);
+
+			// 다음 날로 변경
+			showDate = showDate.plusDays(1);
+
+			// 토요일 공연이면 첫번째 공연 플래그를 변경해준다.
+			if (showDate.getDayOfWeek().equals(DayOfWeek.SATURDAY)) {
+				isSatFirstShow = true;
+			}
+		}
+
+		return requests;
+	}
+
+	private LocalTime setFirstShowTime(DayOfWeek dayOfWeek) {
+		// 토요일 두번째(Special GIG - 1) 공연 시작 시간
+		if (dayOfWeek.equals(DayOfWeek.SATURDAY)) {
+			return LocalTime.of(18, 45);
+		}
+		// 일요일 첫번째 공연 시작 시간
+		if (dayOfWeek.equals(DayOfWeek.SUNDAY)) {
+			return LocalTime.of(18, 30);
+		}
+
+		// 평일 첫번째 공연 시작 시간 (월~금)
+		return LocalTime.of(19, 30);
+	}
+
+	private LocalTime setSecondShowTime(DayOfWeek dayOfWeek) {
+		// 토요일 세번째(Special GIG - 2) 공연 시작 시간
+		if (dayOfWeek.equals(DayOfWeek.SATURDAY)) {
+			return LocalTime.of(21, 10);
+		}
+		// 일요일 두번째 공연 시작 시간
+		if (dayOfWeek.equals(DayOfWeek.SUNDAY)) {
+			return LocalTime.of(20, 40);
+		}
+
+		// 평일 두번째 공연 시작 시간 (월~금)
+		return LocalTime.of(21, 40);
+	}
+}

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/util/TextParser.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/util/TextParser.java
@@ -1,6 +1,9 @@
-package kr.codesquad.jazzmeet.global.util;
+package kr.codesquad.jazzmeet.show.util;
 
 import java.util.List;
+
+import kr.codesquad.jazzmeet.global.error.CustomException;
+import kr.codesquad.jazzmeet.global.error.statuscode.ShowErrorCode;
 
 public class TextParser {
 
@@ -32,5 +35,21 @@ public class TextParser {
 
 		// 시작 공연, 끝 공연
 		return List.of(showStartEndDate[0], showStartEndDate[1]);
+	}
+
+	public static String findDateLine(String text) {
+		String[] splitedText = text.replace(" ", "").split("\n");
+		// text = "안녕하세요 \n \n 12.27 - 12.31 아티스트 라인업입니다!"
+		for (String textLine : splitedText) {
+			if (textLine.isBlank()) {
+				continue;
+			}
+			// 첫 글자에서 숫자(=날짜)가 인식되어야 한다.
+			if (Character.isDigit(textLine.charAt(0))) {
+				return textLine;
+			}
+		}
+
+		throw new CustomException(ShowErrorCode.NOT_FOUND_SHOW_DATE);
 	}
 }

--- a/be/src/main/java/kr/codesquad/jazzmeet/show/util/TextParser.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/util/TextParser.java
@@ -52,4 +52,17 @@ public class TextParser {
 
 		throw new CustomException(ShowErrorCode.NOT_FOUND_SHOW_DATE);
 	}
+
+	public static String findDate(String text) {
+		String temp = text.replace(" ", "");
+		for (int i = 0; i < temp.length(); i++) {
+			char c = temp.charAt(i);
+			// 날짜(=문자)를 찾았다면 "시작 공연 날짜" 부터 추출하여 반환
+			if (Character.isDigit(c)) {
+				return temp.substring(i);
+			}
+		}
+
+		throw new CustomException(ShowErrorCode.OCR_NOT_FOUND_DATE);
+	}
 }


### PR DESCRIPTION
## What is this PR? 👓
### 공연 자동화가 진행되지 않던 문제를 수정했습니다.
- https://github.com/jazz-meet/jazz-meet/issues/366

## Key changes 🔑
### 1. 크롤링 스크립트 수정
- 한 주의 공연 갯수를 검증하는 부분을 `OcrHandler` 에서 하도록 이동.
- 목요일부터 시작하는 공연에 대한 케이스 추가.
  - 화요일부터 시작하는 공연, 수요일부터 시작하는 공연에 대한 케이스만 존재했음.

### 2. 클래스 간 책임 분리
- OcrHandler에서 담당하고 있던 책임을 분리.
    1. 이미지 생성 (`ImageService`로 옮김)
    2. OCR 응답을 공연 등록 Request로 변환 (`ResponseParser` 생성)

## To reviewers 👋
- 리팩토링 진행으로 변경 사항이 많아서 보기 어려울 수 있으니, commit 별로 보시면 좋을 것 같습니다!

## 공연 자동화 언제부터 가능?
- 답변: (4/4 - 4/7) 공연부터 가능할 것 같습니다.
- 이유: 네이버 클로바 OCR에서 **디폴트 템플릿 디자인**으로 설정한 공연 스케줄과 유사하기 때문.
- 또한 EC2환경에서는 인스타그램 **봇 우회하는게 실패**했기 때문에 원래 자동으로 안돌아가는게 맞습니다(흑흑)
    -  로컬에서 수동으로 넣어줘야합니다,, 후후,,

### OCR 인식 정상 - (4/4 - 4/7) 공연
![정상](https://github.com/jazz-meet/jazz-meet/assets/97204689/a638d526-e6cb-43cf-abed-115c1f06b220)


### OCR 인식 비정상 - (3/20 - 3/24) 공연, (3/27 - 3/31) 공연
- 동그라미 친 부분까지 텍스트로 인식해서 오류 발생

![오류](https://github.com/jazz-meet/jazz-meet/assets/97204689/8c65b848-e1ea-4630-9473-2bec9b2d82f2)

