### PR TITLE
refactor: show의 venue 매핑에서 cascade 옵션 삭제

### DIFF
--- a/be/src/main/java/kr/codesquad/jazzmeet/show/entity/Show.java
+++ b/be/src/main/java/kr/codesquad/jazzmeet/show/entity/Show.java
@@ -36,10 +36,10 @@ public class Show {
 	@Column(nullable = false)
 	private LocalDateTime startTime;
 	private LocalDateTime endTime;
-	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "venue_id")
 	private Venue venue;
-	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "poster_id")
 	private Image poster;
 	@ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
### 상황
공연 등록 시 venue id가 자동으로 반영이 안되고 있었습니다.

### 문제 
show 클래스에서 venue 필드의 cascade = CascadeType.PERSIST 옵션은 show 객체가 저장될 때 연결된 venue 객체도 함께 영속화되도록 요청합니다. 하지만 이 설정은 이미 존재하고 영속성 컨텍스트에 관리되고 있는 venue 객체에 대해서는 문제를 야기할 수 있습니다. 예를 들어, **venue 객체가 이미 데이터베이스에 저장되어 관리되고 있다면**, show 객체를 저장할 때 이 옵션이 venue의 기존 상태에 영향을 줄 수 있습니다.

1. **영속성 전파 오류**: 이미 존재하는 venue 객체를 사용할 경우, **CascadeType.PERSIST 설정으로 인해 JPA가 venue 객체를 중복해서 저장하려 시도할 수 있으며, 이는 ID 충돌이나 데이터 무결성 예외를 발생시킬 수 있습니다**.
2. **ID 연결 문제**: show 객체 저장 시 venue 객체의 ID가 show 객체에 제대로 반영되지 않는 문제가 발생할 수 있습니다. 이는 JPA가 venue 객체를 새로운 엔티티로 인식하고 처리하기 때문입니다.

### 해결
```java
@ManyToOne(fetch = FetchType.LAZY)
@JoinColumn(name = "venue_id")
private Venue venue;
```
cascade 옵션 삭제로 venue id를 정상적으로 저장하도록 만들었습니다.